### PR TITLE
fix(seeder): block permissionless Refund of an under-funded committed sink (Critical, S-1c)

### DIFF
--- a/contracts/choice_pool_seeder/src/contract.rs
+++ b/contracts/choice_pool_seeder/src/contract.rs
@@ -1163,17 +1163,29 @@ fn exec_refund(
         });
     }
 
-    // S-1(b): close the post-deadline Settle/Refund race. Once the deadline
-    // passes, `Refund` is permissionless — but a committed sink that ACTUALLY
-    // HOLDS both committed legs can still `Settle` into a healthy pool. Letting
-    // anyone refund it then would permanently deny graduation. So: for a
-    // committed sink (both `expected_*` set), refuse the permissionless refund
-    // when the live balances are `>=` BOTH committed amounts (i.e. it is
-    // settleable). A short leg means the full graduation deposit never landed,
-    // so a refund is the correct terminal state and is allowed (as before).
-    // Only the admin `ForceRefund` (which never calls this function) may
-    // override, for genuinely-unsettleable-but-funded sinks (e.g. an
-    // out-of-range seed ratio that trips `SeedRatioOutOfRange`).
+    // S-1(b)/(c): a COMMITTED sink (both `expected_*` set) is NEVER eligible for
+    // the permissionless `Refund`. The permissionless deadline starts at
+    // instantiate (RegisterLaunch), which can be long before `triggerGraduation`
+    // delivers the seed legs, so a committed sink is only ever in one of two
+    // honest states, and neither should refund here:
+    //
+    //   * S-1(b) — fully funded (both legs >= committed): still settleable, so
+    //     `Settle` (permissionless) must finish graduation; refunding would deny it.
+    //   * S-1(c) — NOT fully funded (one or both legs short): the graduation
+    //     deposit has not (fully) landed. Allowing a refund here is the
+    //     critical bug — a post-deadline 1-wei donation (or even a full single
+    //     leg) would flip a not-yet-funded sink to the terminal `Refunded`
+    //     state, and the real legs that `triggerGraduation` atomically delivers
+    //     afterward would be stranded forever (the sink is `admin: None`, with
+    //     no Settle/Refund/migrate path out of a terminal state). For the
+    //     atomic both-leg delivery model the sink is empty-or-full, so an
+    //     under-funded committed sink means "wait for the deposit, then Settle".
+    //
+    // A genuinely-stuck FUNDED sink (e.g. an out-of-range seed ratio that trips
+    // `SeedRatioOutOfRange`, or a sink caught in a paused incident) is recovered
+    // by the factory-admin `ForceRefund`, which bypasses this function entirely.
+    // Only the uncommitted (direct-instantiate debug) path keeps the legacy
+    // permissionless refund below.
     if let (Some(exp_token), Some(exp_pair)) = (cfg.expected_token, cfg.expected_pair) {
         let token_bal = deps
             .querier
@@ -1186,6 +1198,12 @@ fn exec_refund(
         if token_bal >= exp_token && pair_bal >= exp_pair {
             return Err(ContractError::SinkIsSettleableUseSettle {});
         }
+        return Err(ContractError::SinkRefundUseForceRefund {
+            token_available: token_bal.to_string(),
+            token_expected: exp_token.to_string(),
+            pair_available: pair_bal.to_string(),
+            pair_expected: exp_pair.to_string(),
+        });
     }
 
     do_refund(deps, env, &cfg, state, "refund")

--- a/contracts/choice_pool_seeder/src/error.rs
+++ b/contracts/choice_pool_seeder/src/error.rs
@@ -100,6 +100,16 @@ pub enum ContractError {
     SinkIsSettleableUseSettle {},
 
     #[error(
+        "Refund refused (audit S-1c): committed sink not fully funded ({token_available}/{token_expected} token, {pair_available}/{pair_expected} pair). The permissionless deadline starts at instantiate (RegisterLaunch), long before the graduation deposit lands, so allowing a refund here would let a post-deadline dust/one-leg donation flip a not-yet-funded sink terminal — and the real legs delivered afterward (sink is admin:None, no Settle/Refund/migrate) would be permanently stranded. Wait for the full deposit then Settle, or use the factory-admin ForceRefund for a genuinely-stuck funded sink."
+    )]
+    SinkRefundUseForceRefund {
+        token_available: String,
+        token_expected: String,
+        pair_available: String,
+        pair_expected: String,
+    },
+
+    #[error(
         "XYK graduation is disabled in this build (audit S-5): the production wasm is compiled without the `xyk` feature. Use a CLMM pool_kind, or build with `--features xyk` for the XYK debug/test path."
     )]
     XykDisabled {},

--- a/contracts/choice_pool_seeder/src/tests.rs
+++ b/contracts/choice_pool_seeder/src/tests.rs
@@ -1033,14 +1033,18 @@ fn refund_refused_when_committed_sink_is_settleable() {
     );
 }
 
-/// S-1(b): the refund is STILL allowed when a committed leg is short (the full
-/// graduation deposit never landed, so the sink cannot settle) — the refund is
-/// the correct terminal state for a genuinely-failed launch.
+/// S-1(c): the permissionless `Refund` of a committed sink with a SHORT leg is
+/// now REFUSED. The full graduation deposit has not landed, and the permissionless
+/// deadline starts at instantiate (long before `triggerGraduation` funds the
+/// sink), so refunding here would let the sink go terminal before the real legs
+/// arrive — stranding them permanently. A genuinely-stuck funded sink is
+/// recovered by the factory-admin `ForceRefund`; the launch's own buyers are
+/// refunded EVM-side. The sink must stay `Pending`.
 #[test]
-fn refund_allowed_when_committed_sink_has_short_leg() {
+fn refund_refused_when_committed_sink_has_short_leg() {
     let committed_token = 1_000_000_000_000u128;
     let committed_pair = 800_000_000u128;
-    // Pair leg one wei short ⇒ NOT settleable ⇒ refund proceeds.
+    // Pair leg one wei short ⇒ NOT fully funded ⇒ permissionless refund refused.
     let mut deps = rich_deps(&[
         coin(committed_token, TOKEN_DENOM),
         coin(committed_pair - 1, PAIR_DENOM),
@@ -1050,18 +1054,58 @@ fn refund_allowed_when_committed_sink_has_short_leg() {
     let mut env = mock_env();
     env.block.time = env.block.time.plus_seconds(86_401);
     let caller = deps.api.addr_make("anyone");
-    let res = execute(
+    let err = execute(
         deps.as_mut(),
         env,
         message_info(&caller, &[]),
         ExecuteMsg::Refund {},
     )
-    .unwrap();
-    // token → issuer, short pair → refund_receiver.
-    assert_eq!(res.messages.len(), 2);
+    .unwrap_err();
+    assert!(
+        matches!(err, ContractError::SinkRefundUseForceRefund { .. }),
+        "expected SinkRefundUseForceRefund, got {err:?}"
+    );
     assert_eq!(
         SINK_STATE.load(deps.as_ref().storage).unwrap().status,
-        SinkStatus::Refunded
+        SinkStatus::Pending
+    );
+}
+
+/// S-1(c) (critical regression): the headline griefing vector. A committed sink
+/// that has NOT yet been funded by `triggerGraduation` (e.g. the curve is still
+/// trading) must not be refundable past the deadline just because someone
+/// bank-sent a dust donation to satisfy the old `NothingToRefund` guard. Before
+/// the fix, this flipped the sink to terminal `Refunded`; the graduation legs
+/// delivered afterward would then be stranded in a dead sink forever. The refund
+/// must now be refused and the sink left `Pending` so `Settle` can still finish
+/// graduation once the deposit lands.
+#[test]
+fn refund_refused_when_committed_sink_underfunded_post_deadline() {
+    let committed_token = 1_000_000_000_000u128;
+    let committed_pair = 800_000_000u128;
+    // Sink holds NO graduation deposit — only a 1-wei pair-denom dust donation an
+    // attacker bank-sent to get past the legacy `NothingToRefund` guard.
+    let mut deps = rich_deps(&[coin(1u128, PAIR_DENOM)]);
+    instantiate_sink_committed(&mut deps, committed_token, committed_pair);
+
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(86_401); // past the deadline
+    let attacker = deps.api.addr_make("griefer");
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&attacker, &[]),
+        ExecuteMsg::Refund {},
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ContractError::SinkRefundUseForceRefund { .. }),
+        "expected SinkRefundUseForceRefund, got {err:?}"
+    );
+    // Sink stays Pending: a later `triggerGraduation` delivery can still Settle.
+    assert_eq!(
+        SINK_STATE.load(deps.as_ref().storage).unwrap().status,
+        SinkStatus::Pending
     );
 }
 


### PR DESCRIPTION
## Summary

Pre-mainnet security review of the SHROOM launchpad / seeder / issuer surfaced one **Critical** cross-VM lifecycle bug in `choice_pool_seeder`. This PR fixes it.

## The bug (Critical — permanent loss of graduation liquidity, ~free, permissionless)

A per-launch sink's permissionless `Refund` deadline is measured from **`instantiated_at`** (set at `RegisterLaunch`, i.e. launch registration). But the sink only receives funds much later, at **`triggerGraduation`** — whenever the bonding curve fills. With the keeper's `SINK_DEADLINE_SECONDS=86400` (24h), any launch whose curve outlives 24h (common) is exposed:

1. Sink instantiated at registration; deadline = `now + 24h`. Sink holds nothing (for SHROOM `cw_held == 0`; both legs arrive only at graduation).
2. 24h passes while the curve is still trading.
3. Attacker bank-sends **1 wei** of `pair_denom` to the sink and calls `Refund{}`. The existing `S-1(b)` guard only blocks a *fully-funded* (settleable) sink, so an under-funded one passes ("short leg") and `do_refund` flips it to terminal **`Refunded`** — exactly what the old `refund_allowed_when_committed_sink_has_short_leg` test asserted.
4. Curve fills; anyone calls `triggerGraduation` → `Phase3Settler` atomically forwards `realPair` (the full graduation INJ) + the launch-token reserve into the **dead sink** (`admin: None`, no `Settle`/`Refund`/`migrate` out of terminal). **Liquidity stranded permanently.** EVM side is left stuck in `PendingSettlement` with no recovery (`adminForceFail`/`forceFailTrading` only accept `CurveFilled`/`Trading`).

## The fix (S-1c)

A **committed** sink (both `expected_*` set — every production sink) is now **never eligible for the permissionless `Refund`**. Under atomic both-leg delivery a committed sink is only ever empty-or-full:

- **fully funded** → `SinkIsSettleableUseSettle` (S-1b, unchanged) — `Settle` is permissionless and finishes graduation;
- **not fully funded** → new `SinkRefundUseForceRefund` — wait for the deposit then `Settle`.

A genuinely-stuck **funded-but-unsettleable** sink (e.g. `SeedRatioOutOfRange`, paused incident) is still recovered by the factory-admin **`ForceRefund`**, which bypasses this path and is unchanged. The **uncommitted** direct-instantiate (debug) path keeps the legacy permissionless refund.

Net effect: `SINK_DEADLINE_SECONDS` becomes irrelevant for production sinks — the "deadline starts too early" knob can no longer be turned into a vulnerability.

### Why not "reject only when both legs are dust"?
That only raises the attack cost: an attacker donating one **full** committed leg (≈ graduation value) could still brick the sink, which can be rational for a high-value launch. Disabling the permissionless refund for committed sinks closes it at any cost. SHROOM's atomic delivery means no legitimate committed-sink permissionless refund exists, so nothing is lost.

**Tradeoff:** a future non-SHROOM consumer with *non-atomic* Leg-B/Leg-C delivery that wants permissionless partial refunds would reintroduce an "≥1 full leg" variant for its sinks; for SHROOM that path is impossible.

## Tests

- `refund_refused_when_committed_sink_underfunded_post_deadline` — **new**, the headline grief regression (dust donation → `SinkRefundUseForceRefund`, sink stays `Pending`).
- `refund_refused_when_committed_sink_has_short_leg` — repurposed from `refund_allowed_…` to assert rejection + `Pending`.
- `refund_refused_when_committed_sink_is_settleable` (S-1b), uncommitted-path refund, pre-deadline, and nothing-to-refund tests unchanged and green.

`cargo test -p choice-pool-seeder --lib`: **68 passed**; with `--features xyk`: **84 passed**. `cargo fmt` + `cargo clippy` clean.

## Notes / follow-ups (out of scope for this PR)
- **Medium (related):** the `SinkInit.refund_receiver` doc claims `LaunchpadCore` performs proportional buyer refunds on a sink refund, but no EVM ingest path implements it; a post-graduation sink refund leaves the pair only admin-sweepable. With this fix a committed sink can no longer be refunded out from under graduation, but the doc/runbook should still be corrected.
- Full review write-up available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)