### PR TITLE
fix(issuer): reject funds and dead-address admin at instantiate

### DIFF
--- a/contracts/choice_mts_issuer/src/contract.rs
+++ b/contracts/choice_mts_issuer/src/contract.rs
@@ -102,10 +102,17 @@ struct ReplyPayload {
 pub fn instantiate(
     deps: DepsMut<InjectiveQueryWrapper>,
     _env: Env,
-    _info: MessageInfo,
+    info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response<InjectiveMsgWrapper>, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // Instantiate accepts no funds. The CreateDenom fee is paid per-launch at
+    // RegisterLaunch, never here — any attached coin would be silently absorbed
+    // into the contract balance with no recovery path, so reject up front.
+    if !info.funds.is_empty() {
+        return Err(ContractError::InstantiateDoesNotAcceptFunds {});
+    }
 
     validate_subdenom_prefix(&msg.subdenom_prefix)?;
     if msg.decimals > MAX_DECIMALS {
@@ -119,6 +126,14 @@ pub fn instantiate(
     }
 
     let admin = deps.api.addr_validate(&msg.admin)?;
+    // The admin governs the issuer via a two-step handoff (UpdateAdmin/
+    // AcceptAdmin). Setting it to the tokenfactory dead-burn address at deploy
+    // would permanently brick governance (no key can ever AcceptAdmin), so
+    // reject the obvious foot-gun. Rotation to the dead address is still
+    // possible later only through the denom-admin renounce path, not here.
+    if admin.as_str() == DEAD_TOKENFACTORY_ADMIN {
+        return Err(ContractError::AdminIsDeadAddress {});
+    }
     let keeper = deps.api.addr_validate(&msg.keeper)?;
     let forwarder = deps.api.addr_validate(&msg.forwarder)?;
 

--- a/contracts/choice_mts_issuer/src/error.rs
+++ b/contracts/choice_mts_issuer/src/error.rs
@@ -24,6 +24,14 @@ pub enum ContractError {
     #[error("No pending admin to accept")]
     NoPendingAdmin {},
 
+    #[error("instantiate does not accept funds (the CreateDenom fee is paid per-launch at RegisterLaunch)")]
+    InstantiateDoesNotAcceptFunds {},
+
+    #[error(
+        "admin must not be the tokenfactory dead-burn address (would permanently brick governance)"
+    )]
+    AdminIsDeadAddress {},
+
     #[error("Subdenom prefix `{got}` is empty or exceeds the {max}-char cap")]
     SubdenomPrefixInvalid { got: String, max: usize },
 

--- a/contracts/choice_mts_issuer/src/tests.rs
+++ b/contracts/choice_mts_issuer/src/tests.rs
@@ -310,6 +310,54 @@ fn instantiate_rejects_decimals_over_18() {
 }
 
 #[test]
+fn instantiate_rejects_attached_funds() {
+    let mut deps = new_deps();
+    let admin = deps.api.addr_make("admin");
+    let msg = InstantiateMsg {
+        admin: admin.to_string(),
+        subdenom_prefix: PREFIX.to_string(),
+        decimals: 18,
+        keeper: deps.api.addr_make("keeper").to_string(),
+        forwarder: deps.api.addr_make("forwarder").to_string(),
+        refund_deadline_seconds: REFUND_DEADLINE,
+    };
+    // Any attached coin is rejected — the CreateDenom fee is paid per-launch at
+    // RegisterLaunch, never here.
+    let err = instantiate(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin, &[coin(1, CREATE_FEE_DENOM)]),
+        msg,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::InstantiateDoesNotAcceptFunds {}
+    ));
+}
+
+#[test]
+fn instantiate_rejects_dead_admin() {
+    let mut deps = new_deps();
+    // The dead-burn constant is `inj`-prefixed; switch the mock api off the
+    // default `cosmwasm` prefix so `addr_validate` accepts it and the guard
+    // (which runs after validation) is the thing under test.
+    deps.api = MockApi::default().with_prefix("inj");
+    let sender = deps.api.addr_make("admin");
+    let msg = InstantiateMsg {
+        // 20-zero-byte tokenfactory dead-burn bech32 — would brick governance.
+        admin: "inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49".to_string(),
+        subdenom_prefix: PREFIX.to_string(),
+        decimals: 18,
+        keeper: deps.api.addr_make("keeper").to_string(),
+        forwarder: deps.api.addr_make("forwarder").to_string(),
+        refund_deadline_seconds: REFUND_DEADLINE,
+    };
+    let err = instantiate(deps.as_mut(), mock_env(), message_info(&sender, &[]), msg).unwrap_err();
+    assert!(matches!(err, ContractError::AdminIsDeadAddress {}));
+}
+
+#[test]
 fn register_launch_emits_expected_message_chain_and_persists_record() {
     let mut deps = setup();
     let res = register_default(&mut deps, 42).unwrap();


### PR DESCRIPTION
## Summary

Two deploy-time foot-gun guards in `choice_mts_issuer::instantiate`, from the pre-mainnet security review (both Low/hardening — instantiate is deploy-time so neither is external-attacker reachable, but each closes a permanent-brick / stranded-funds misconfiguration window).

### 1. Reject attached funds
`instantiate` previously ignored `info` entirely. The CreateDenom fee is paid per-launch at `RegisterLaunch`, never at instantiate — any coin attached at deploy would be silently absorbed into the contract balance with no recovery path. Now rejected with `InstantiateDoesNotAcceptFunds`.

### 2. Reject the dead-burn address as admin
The admin governs the issuer via a two-step `UpdateAdmin`/`AcceptAdmin` handoff. Setting it to the tokenfactory dead-burn bech32 (`inj1qqq…e2hm49`) at deploy would permanently brick governance (no key can ever `AcceptAdmin`). Now rejected with `AdminIsDeadAddress`. Rotation to the dead address remains possible later only via the denom-admin renounce path, not here.

## Tests
- `instantiate_rejects_attached_funds`
- `instantiate_rejects_dead_admin` — switches the mock api to the `inj` prefix so the inj-prefixed dead constant validates and the guard (which runs after `addr_validate`) is what's exercised.
- `cargo test -p choice-mts-issuer` **65/0**, `cargo fmt --check` clean, `cargo clippy` clean.

## Scope
Issuer `instantiate` only — no change to RegisterLaunch / mint / delivery / renounce logic. Base branch is the pre-mainnet integration branch (on top of the merged seeder S-1c fix, #23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)