### PR TITLE
feat(claim-drops): multi-campaign cumulative merkle claim-drop contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "choice-claim-drops"
+version = "1.1.0"
+dependencies = [
+ "cosmwasm-schema 2.2.2",
+ "cosmwasm-std 2.2.2",
+ "cw-storage-plus 2.0.0",
+ "cw2 2.0.0",
+ "ed25519-zebra 4.1.0",
+ "schemars 0.8.22",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "choice-clmm-common"
 version = "1.1.2"
 dependencies = [

--- a/contracts/choice_claim_drops/Cargo.toml
+++ b/contracts/choice_claim_drops/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "choice-claim-drops"
+version = "1.1.0"
+authors = ["Dan Van Eijck"]
+edition = "2021"
+description = "Multi-campaign cumulative merkle claim-drop hub. Anyone creates a campaign for a native denom and publishes a merkle root of lifetime cumulative allocations; recipients claim `allocated − claimed` with a proof. Re-publishing a root with a higher declared total requires attaching exactly the delta, so one contract serves both one-shot airdrops (root frozen after funding) and keeper-driven reward streams (daily root updates)."
+license = "Apache-2.0"
+
+exclude = [
+  "contract.wasm",
+  "hash.txt",
+]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+library = []
+
+[dependencies]
+cw2               = { version = "2.0.0" }
+cosmwasm-std      = { version = "2.2.2", features = [
+    "abort",
+    "cosmwasm_1_2",
+    "cosmwasm_1_3",
+    "cosmwasm_1_4",
+    "cosmwasm_2_0",
+    "iterator",
+    "stargate"
+] }
+cw-storage-plus   = { version = "2.0.0" }
+cosmwasm-schema   = { version = "2.2.2" }
+sha2              = { version = "0.10.9", default-features = false }
+thiserror         = { version = "2.0.12" }
+
+# Workspace dependency-feature unification: cosmwasm-crypto's ed25519 `batch`
+# path requires the `alloc` feature on ed25519-zebra. Other crates in this
+# workspace pull it in via injective-cosmwasm; this contract has no Injective-
+# specific surface, so depend on it directly with the right feature so a
+# standalone `cargo build -p choice-claim-drops` works.
+ed25519-zebra     = { version = "4.1.0", default-features = false, features = ["alloc"] }
+
+schemars          = "0.8.22"
+serde             = { version = "1.0.219", default-features = false, features = ["derive"] }

--- a/contracts/choice_claim_drops/README.md
+++ b/contracts/choice_claim_drops/README.md
@@ -1,0 +1,119 @@
+# choice-claim-drops
+
+Multi-campaign cumulative merkle claim-drop hub. One deployed contract hosts
+any number of independent claim campaigns — one-shot community airdrops
+(trippytools "Claim Drop"), high-value single drops, and keeper-driven reward
+streams (Trippy Terminal trading rewards) — all as the same object with
+different lifecycles.
+
+## Two kinds of campaign — the safety model
+
+Publishing a merkle root is the power to direct a campaign's unclaimed float
+(the contract can't see leaves, so it trusts the publisher on the tree). The
+contract splits campaigns so that power is only ever held where it's safe:
+
+- **One-shot (`streaming: false`)** — permissionless. Auto-frozen on its first
+  published root, so its already-funded float can **never** be reassigned by a
+  later republish. This is the mode for community airdrops and high-value single
+  drops. Create + fund + publish + freeze can happen in a single tx (see
+  `initial`), so the claim link is never shareable before the root is immutable.
+- **Streaming (`streaming: true`)** — **owner-only.** Accepts repeated
+  `UpdateRoot`s and an optional keeper bot, for daily reward epochs. The mutable
+  root is a trusted-updater surface: whoever holds the creator or keeper key can
+  reassign the campaign's unclaimed float. Keep the keeper key hot-but-poor
+  (≤ one epoch's emission) and cap the contract's streaming float accordingly.
+  A streaming campaign can be `Freeze`d by the owner to end it.
+
+### Solvency invariant
+
+`UpdateRoot { root, total, leaves_uri }` (and `CreateCampaign { initial }`) must
+attach **exactly `total − previous_total`** of the campaign denom, plus the
+platform fee on that delta (charged on top, ceil-rounded) if `fee_bps` is set.
+`total` can never decrease, and every payout is hard-capped at
+`total − claimed_total`, which confines a dishonest tree to its own campaign's
+balance — campaigns are fully isolated.
+
+Each funding delta is booked into a per-denom **liabilities** ledger; the
+owner-only `Rescue` can sweep only `bank_balance − liabilities`, so tokens
+mis-sent to the contract are recoverable while claimant funds never are.
+
+### Dual-root claim window
+
+The previous root stays claimable after an update, so proofs fetched just before
+a keeper publish don't race to failure. Safe under cumulative semantics: an old
+leaf only ever claims less.
+
+### Freeze / expiry / clawback
+
+`expiry: None` = perpetual. While unexpired, `SetExpiry` may only *extend*;
+winding down a perpetual campaign requires ≥ 7 days notice. **A frozen perpetual
+campaign's expiry is locked** — it can never be given an expiry, so an
+"immutable" drop can never be clawed back. After expiry, claims stop and
+`Clawback` returns the unclaimed remainder to the creator (once). Use the
+two-step `TransferCreator` to rotate a lost/compromised creator key before it
+strands that remainder.
+
+## Merkle tree spec (cross-language)
+
+Any tree builder (TS keeper, trippytools frontend) must reproduce this
+byte-for-byte — golden vectors are pinned in `src/merkle.rs` tests:
+
+```text
+leaf   = sha256(utf8("{bech32_address}:{cumulative_amount_base_units}"))
+parent = sha256(concat(min(a, b), max(a, b)))      // sorted-pair, no L/R flags
+```
+
+- Address: canonical lowercase bech32 (`inj1…`), exactly as the chain returns it.
+- Amount: decimal string of the lifetime cumulative allocation in base units,
+  no separators (`"1000000"`).
+- Odd node at any level promotes unchanged (its proof omits that level).
+- Single-leaf tree: the leaf is the root; the proof is empty.
+- **Deduplicate addresses** before building; set `total == Σ leaf amounts`
+  exactly (over-declaring strands funds until clawback; under-declaring makes
+  some leaves unclaimable).
+
+Publishers upload the full `(address, amount)` leaves file to `leaves_uri`
+(stored on-chain per campaign): clients rebuild the tree locally and derive
+their own proofs, and the file doubles as the public audit record.
+
+## Messages
+
+| Message | Who | Notes |
+|---|---|---|
+| `CreateCampaign { denom, meta, keeper?, expiry?, streaming, initial? }` | anyone (streaming: owner) | `initial` publishes+funds the first root in-tx; one-shots auto-freeze |
+| `UpdateRoot { id, root, total, leaves_uri }` | creator / keeper | attach exactly `delta (+ fee)`; one-shot auto-freezes after |
+| `Freeze { id }` | creator | one-way; also locks expiry when perpetual |
+| `Claim { id, amount, proof }` | claimant | pays `amount − claimed`; current or previous root |
+| `ClaimMany { claims, allow_partial? }` | claimant | `allow_partial` skips closed/exhausted claims instead of reverting |
+| `Clawback { id }` | creator | after expiry, once |
+| `Rescue { denom, amount?, recipient? }` | owner | sweeps only `balance − liabilities` |
+| `TransferOwnership`/`AcceptOwnership` | owner → new | two-step |
+| `TransferCreator { id }`/`AcceptCreator { id }` | creator → new | two-step; moves the creator index |
+| `SetKeeper` (streaming only) / `SetExpiry` / `SetCampaignPaused` / `UpdateMeta` | creator | expiry extend-only; frozen perpetual locked |
+| `UpdateConfig { fee_bps?, fee_collector?, paused? }` | owner | fee_bps ≤ 1000; ownership moves via the two-step flow |
+
+Queries: `Config`, `Campaign`, `Campaigns`, `CampaignsByCreator`, `Claimed`,
+`Claims { id, start_after, limit }` (paginated claimants for the manage view),
+`Claimable { id, address, amount, proof }` (dry-run → validity + payable now),
+`FundingRequired { id, new_total }` (exact `delta`/`fee`/`required` to attach),
+and `Liabilities { denom }` (owed vs. bank balance reconciliation).
+
+Events: `create_campaign` (id, creator, denom, streaming, keeper, expiry),
+`update_root` (id, root, total, delta, fee), `claim` (id, claimant, cumulative,
+payout, denom — emitted per-claim from both `Claim` and `ClaimMany`),
+`claim_skipped`, `clawback`, `rescue`, plus the admin actions.
+
+## Build & test
+
+```bash
+cargo test -p choice-claim-drops
+cargo build --release --target wasm32-unknown-unknown -p choice-claim-drops
+cd contracts/choice_claim_drops && cargo run --example schema   # run from the contract dir
+./build_release.sh                                              # optimized artifact
+```
+
+## Deferred (future work)
+
+Root-update timelock for streaming campaigns (URD-style veto window — migrate to
+add if a streaming campaign ever holds enough float to justify it; the contract
+sits behind `choice_admin_timelock`), claim-on-behalf, batch `Claimable`.

--- a/contracts/choice_claim_drops/examples/schema.rs
+++ b/contracts/choice_claim_drops/examples/schema.rs
@@ -1,0 +1,12 @@
+use cosmwasm_schema::write_api;
+
+use choice_claim_drops::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+        migrate: MigrateMsg,
+    }
+}

--- a/contracts/choice_claim_drops/schema/choice-claim-drops.json
+++ b/contracts/choice_claim_drops/schema/choice-claim-drops.json
@@ -1,0 +1,1595 @@
+{
+  "contract_name": "choice-claim-drops",
+  "contract_version": "1.1.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "required": [
+      "fee_bps"
+    ],
+    "properties": {
+      "fee_bps": {
+        "description": "Platform fee in bps charged on top of funding deltas. Capped at 1000 (10%).",
+        "type": "integer",
+        "format": "uint16",
+        "minimum": 0.0
+      },
+      "fee_collector": {
+        "description": "Defaults to the owner.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "owner": {
+        "description": "Defaults to the instantiator.",
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "description": "Open a new campaign.\n\n`streaming` campaigns accept repeated `UpdateRoot`s and a keeper, and may ONLY be created by the contract owner. A non-owner (or `streaming:false`) creates a one-shot: it is auto-frozen on its first published root, so its already-funded float can never be reassigned by a later republish.\n\nPass `initial` to publish the first root in the same tx (attach `total + fee`); omit it (no funds) to publish later via `UpdateRoot`.",
+        "type": "object",
+        "required": [
+          "create_campaign"
+        ],
+        "properties": {
+          "create_campaign": {
+            "type": "object",
+            "required": [
+              "denom",
+              "meta",
+              "streaming"
+            ],
+            "properties": {
+              "denom": {
+                "type": "string"
+              },
+              "expiry": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Timestamp"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "initial": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/InitialRoot"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "keeper": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "meta": {
+                "type": "string"
+              },
+              "streaming": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Publish (or, for streaming campaigns, replace) the merkle root of lifetime cumulative allocations. `total` may only rise; attach exactly `total - previous_total` plus the platform fee on that delta. Creator or keeper. A one-shot campaign is auto-frozen after this call.",
+        "type": "object",
+        "required": [
+          "update_root"
+        ],
+        "properties": {
+          "update_root": {
+            "type": "object",
+            "required": [
+              "id",
+              "leaves_uri",
+              "root",
+              "total"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "leaves_uri": {
+                "type": "string"
+              },
+              "root": {
+                "$ref": "#/definitions/HexBinary"
+              },
+              "total": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "One-way: permanently lock the root, and (if perpetual) the expiry policy. Auto-invoked on a one-shot's first publish; the owner may also call it on a streaming campaign to end it.",
+        "type": "object",
+        "required": [
+          "freeze"
+        ],
+        "properties": {
+          "freeze": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Claim `amount − already_claimed`, where `amount` is the sender's cumulative leaf value proven against the current or previous root.",
+        "type": "object",
+        "required": [
+          "claim"
+        ],
+        "properties": {
+          "claim": {
+            "type": "object",
+            "required": [
+              "amount",
+              "id",
+              "proof"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Uint128"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "proof": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/HexBinary"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Claim across several campaigns in one tx (portfolio \"claim all\"). `allow_partial` (default false): when true, individual claims that would fail (paused / expired / already-claimed) are skipped rather than reverting the whole tx; errors only if every claim is skipped.",
+        "type": "object",
+        "required": [
+          "claim_many"
+        ],
+        "properties": {
+          "claim_many": {
+            "type": "object",
+            "required": [
+              "claims"
+            ],
+            "properties": {
+              "allow_partial": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "claims": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/ClaimMsg"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "After expiry the creator sweeps whatever was never claimed.",
+        "type": "object",
+        "required": [
+          "clawback"
+        ],
+        "properties": {
+          "clawback": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Recover tokens sent to the contract outside campaign accounting (wrong address, wrong denom). Owner-only; capped at `balance − liabilities` so it can never touch funds owed to claimants. Defaults: sweep all excess to the owner.",
+        "type": "object",
+        "required": [
+          "rescue"
+        ],
+        "properties": {
+          "rescue": {
+            "type": "object",
+            "required": [
+              "denom"
+            ],
+            "properties": {
+              "amount": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Uint128"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "denom": {
+                "type": "string"
+              },
+              "recipient": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Two-step ownership transfer (propose → accept).",
+        "type": "object",
+        "required": [
+          "transfer_ownership"
+        ],
+        "properties": {
+          "transfer_ownership": {
+            "type": "object",
+            "required": [
+              "new_owner"
+            ],
+            "properties": {
+              "new_owner": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "accept_ownership"
+        ],
+        "properties": {
+          "accept_ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Two-step per-campaign creator transfer (rotate a creator key).",
+        "type": "object",
+        "required": [
+          "transfer_creator"
+        ],
+        "properties": {
+          "transfer_creator": {
+            "type": "object",
+            "required": [
+              "id",
+              "new_creator"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "new_creator": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "accept_creator"
+        ],
+        "properties": {
+          "accept_creator": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "set_keeper"
+        ],
+        "properties": {
+          "set_keeper": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "keeper": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Extend an expiry, or wind down a perpetual campaign with ≥7 days notice. A frozen perpetual campaign's expiry is locked.",
+        "type": "object",
+        "required": [
+          "set_expiry"
+        ],
+        "properties": {
+          "set_expiry": {
+            "type": "object",
+            "required": [
+              "expiry",
+              "id"
+            ],
+            "properties": {
+              "expiry": {
+                "$ref": "#/definitions/Timestamp"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "set_campaign_paused"
+        ],
+        "properties": {
+          "set_campaign_paused": {
+            "type": "object",
+            "required": [
+              "id",
+              "paused"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "paused": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_meta"
+        ],
+        "properties": {
+          "update_meta": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "leaves_uri": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "meta": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Owner config. Ownership is transferred via the two-step flow, not here.",
+        "type": "object",
+        "required": [
+          "update_config"
+        ],
+        "properties": {
+          "update_config": {
+            "type": "object",
+            "properties": {
+              "fee_bps": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint16",
+                "minimum": 0.0
+              },
+              "fee_collector": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "paused": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "ClaimMsg": {
+        "type": "object",
+        "required": [
+          "amount",
+          "id",
+          "proof"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "id": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "proof": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/HexBinary"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "HexBinary": {
+        "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "InitialRoot": {
+        "description": "A root published atomically with `CreateCampaign` — lets a one-shot drop be created, funded, and (being non-streaming) auto-frozen in a single tx, so the claim link is never shareable before the root is immutable. Attach exactly `total + fee`.",
+        "type": "object",
+        "required": [
+          "leaves_uri",
+          "root",
+          "total"
+        ],
+        "properties": {
+          "leaves_uri": {
+            "type": "string"
+          },
+          "root": {
+            "$ref": "#/definitions/HexBinary"
+          },
+          "total": {
+            "$ref": "#/definitions/Uint128"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "campaign"
+        ],
+        "properties": {
+          "campaign": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "campaigns"
+        ],
+        "properties": {
+          "campaigns": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "campaigns_by_creator"
+        ],
+        "properties": {
+          "campaigns_by_creator": {
+            "type": "object",
+            "required": [
+              "creator"
+            ],
+            "properties": {
+              "creator": {
+                "type": "string"
+              },
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "claimed"
+        ],
+        "properties": {
+          "claimed": {
+            "type": "object",
+            "required": [
+              "address",
+              "id"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Paginated list of a campaign's claimants + their cumulative claimed amounts. Powers the trippytools manage view without an off-chain indexer.",
+        "type": "object",
+        "required": [
+          "claims"
+        ],
+        "properties": {
+          "claims": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Dry-run a claim: proof validity plus the payable amount right now (zero when the campaign is paused, expired, swept, or exhausted).",
+        "type": "object",
+        "required": [
+          "claimable"
+        ],
+        "properties": {
+          "claimable": {
+            "type": "object",
+            "required": [
+              "address",
+              "amount",
+              "id",
+              "proof"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "amount": {
+                "$ref": "#/definitions/Uint128"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "proof": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/HexBinary"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Exact funds to attach to move a campaign's declared total to `new_total`, so integrators never have to replicate the fee rounding.",
+        "type": "object",
+        "required": [
+          "funding_required"
+        ],
+        "properties": {
+          "funding_required": {
+            "type": "object",
+            "required": [
+              "id",
+              "new_total"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "new_total": {
+                "$ref": "#/definitions/Uint128"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Amount currently owed to claimants for a denom (Σ remaining across its campaigns). Reconcile against the contract's bank balance.",
+        "type": "object",
+        "required": [
+          "liabilities"
+        ],
+        "properties": {
+          "liabilities": {
+            "type": "object",
+            "required": [
+              "denom"
+            ],
+            "properties": {
+              "denom": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "HexBinary": {
+        "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "migrate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MigrateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "sudo": null,
+  "responses": {
+    "campaign": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "CampaignResponse",
+      "type": "object",
+      "required": [
+        "campaign",
+        "id",
+        "remaining"
+      ],
+      "properties": {
+        "campaign": {
+          "$ref": "#/definitions/Campaign"
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "remaining": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Campaign": {
+          "type": "object",
+          "required": [
+            "claimants",
+            "claimed_total",
+            "creator",
+            "denom",
+            "frozen",
+            "leaves_uri",
+            "meta",
+            "paused",
+            "prev_total",
+            "streaming",
+            "swept",
+            "total"
+          ],
+          "properties": {
+            "claimants": {
+              "description": "Count of distinct addresses that have claimed at least once (manage-view stat; avoids paginating every claimant just to count).",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "claimed_total": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "creator": {
+              "$ref": "#/definitions/Addr"
+            },
+            "denom": {
+              "description": "Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).",
+              "type": "string"
+            },
+            "expiry": {
+              "description": "After expiry claims stop and the creator may claw back the remainder. `None` = perpetual.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "frozen": {
+              "description": "One-way switch blocking all future root updates. Auto-set on a one-shot campaign's first publish; the owner may also set it on a streaming campaign to end it. Also locks the expiry policy (a frozen perpetual drop can never be given an expiry, so it can never be clawed back).",
+              "type": "boolean"
+            },
+            "keeper": {
+              "description": "Optional second address allowed to publish roots — the rewards keeper bot for streaming campaigns. Only meaningful when `streaming`.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "leaves_uri": {
+              "description": "Where the full `(address, cumulative_amount)` leaves file for `root` is published. Clients rebuild the tree from it and derive their own proofs; it doubles as the public audit record of the campaign.",
+              "type": "string"
+            },
+            "meta": {
+              "description": "Free-form JSON rendered by frontends (title, logo, description).",
+              "type": "string"
+            },
+            "paused": {
+              "type": "boolean"
+            },
+            "pending_creator": {
+              "description": "Two-step creator transfer target (rotate a lost/compromised creator key without stranding the campaign's clawback + admin powers).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "prev_root": {
+              "description": "The previous root stays claimable after an update so proofs fetched just before a keeper publish don't race to failure. Safe under cumulative semantics: an old leaf only ever claims less.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "prev_total": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "root": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "streaming": {
+              "description": "Streaming campaigns accept repeated root updates and a keeper; ONLY the contract owner may create them (the mutable root is a trusted-updater surface — see README threat model). Non-streaming (\"one-shot\") campaigns are auto-frozen on their first root publish, so a permissionless creator can never republish over already-funded float. This split is the core of the contract's safety model.",
+              "type": "boolean"
+            },
+            "swept": {
+              "type": "boolean"
+            },
+            "total": {
+              "description": "Declared sum of all leaf amounts under `root`. The contract cannot see the leaves, so honesty here is the publisher's responsibility; claims are hard-capped at `total - claimed_total` regardless, which confines a dishonest tree to its own campaign's balance.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "HexBinary": {
+          "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "campaigns": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_CampaignResponse",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CampaignResponse"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Campaign": {
+          "type": "object",
+          "required": [
+            "claimants",
+            "claimed_total",
+            "creator",
+            "denom",
+            "frozen",
+            "leaves_uri",
+            "meta",
+            "paused",
+            "prev_total",
+            "streaming",
+            "swept",
+            "total"
+          ],
+          "properties": {
+            "claimants": {
+              "description": "Count of distinct addresses that have claimed at least once (manage-view stat; avoids paginating every claimant just to count).",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "claimed_total": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "creator": {
+              "$ref": "#/definitions/Addr"
+            },
+            "denom": {
+              "description": "Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).",
+              "type": "string"
+            },
+            "expiry": {
+              "description": "After expiry claims stop and the creator may claw back the remainder. `None` = perpetual.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "frozen": {
+              "description": "One-way switch blocking all future root updates. Auto-set on a one-shot campaign's first publish; the owner may also set it on a streaming campaign to end it. Also locks the expiry policy (a frozen perpetual drop can never be given an expiry, so it can never be clawed back).",
+              "type": "boolean"
+            },
+            "keeper": {
+              "description": "Optional second address allowed to publish roots — the rewards keeper bot for streaming campaigns. Only meaningful when `streaming`.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "leaves_uri": {
+              "description": "Where the full `(address, cumulative_amount)` leaves file for `root` is published. Clients rebuild the tree from it and derive their own proofs; it doubles as the public audit record of the campaign.",
+              "type": "string"
+            },
+            "meta": {
+              "description": "Free-form JSON rendered by frontends (title, logo, description).",
+              "type": "string"
+            },
+            "paused": {
+              "type": "boolean"
+            },
+            "pending_creator": {
+              "description": "Two-step creator transfer target (rotate a lost/compromised creator key without stranding the campaign's clawback + admin powers).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "prev_root": {
+              "description": "The previous root stays claimable after an update so proofs fetched just before a keeper publish don't race to failure. Safe under cumulative semantics: an old leaf only ever claims less.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "prev_total": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "root": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "streaming": {
+              "description": "Streaming campaigns accept repeated root updates and a keeper; ONLY the contract owner may create them (the mutable root is a trusted-updater surface — see README threat model). Non-streaming (\"one-shot\") campaigns are auto-frozen on their first root publish, so a permissionless creator can never republish over already-funded float. This split is the core of the contract's safety model.",
+              "type": "boolean"
+            },
+            "swept": {
+              "type": "boolean"
+            },
+            "total": {
+              "description": "Declared sum of all leaf amounts under `root`. The contract cannot see the leaves, so honesty here is the publisher's responsibility; claims are hard-capped at `total - claimed_total` regardless, which confines a dishonest tree to its own campaign's balance.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "CampaignResponse": {
+          "type": "object",
+          "required": [
+            "campaign",
+            "id",
+            "remaining"
+          ],
+          "properties": {
+            "campaign": {
+              "$ref": "#/definitions/Campaign"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "remaining": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        },
+        "HexBinary": {
+          "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "campaigns_by_creator": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Array_of_CampaignResponse",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CampaignResponse"
+      },
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Campaign": {
+          "type": "object",
+          "required": [
+            "claimants",
+            "claimed_total",
+            "creator",
+            "denom",
+            "frozen",
+            "leaves_uri",
+            "meta",
+            "paused",
+            "prev_total",
+            "streaming",
+            "swept",
+            "total"
+          ],
+          "properties": {
+            "claimants": {
+              "description": "Count of distinct addresses that have claimed at least once (manage-view stat; avoids paginating every claimant just to count).",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "claimed_total": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "creator": {
+              "$ref": "#/definitions/Addr"
+            },
+            "denom": {
+              "description": "Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).",
+              "type": "string"
+            },
+            "expiry": {
+              "description": "After expiry claims stop and the creator may claw back the remainder. `None` = perpetual.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "frozen": {
+              "description": "One-way switch blocking all future root updates. Auto-set on a one-shot campaign's first publish; the owner may also set it on a streaming campaign to end it. Also locks the expiry policy (a frozen perpetual drop can never be given an expiry, so it can never be clawed back).",
+              "type": "boolean"
+            },
+            "keeper": {
+              "description": "Optional second address allowed to publish roots — the rewards keeper bot for streaming campaigns. Only meaningful when `streaming`.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "leaves_uri": {
+              "description": "Where the full `(address, cumulative_amount)` leaves file for `root` is published. Clients rebuild the tree from it and derive their own proofs; it doubles as the public audit record of the campaign.",
+              "type": "string"
+            },
+            "meta": {
+              "description": "Free-form JSON rendered by frontends (title, logo, description).",
+              "type": "string"
+            },
+            "paused": {
+              "type": "boolean"
+            },
+            "pending_creator": {
+              "description": "Two-step creator transfer target (rotate a lost/compromised creator key without stranding the campaign's clawback + admin powers).",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "prev_root": {
+              "description": "The previous root stays claimable after an update so proofs fetched just before a keeper publish don't race to failure. Safe under cumulative semantics: an old leaf only ever claims less.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "prev_total": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "root": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/HexBinary"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "streaming": {
+              "description": "Streaming campaigns accept repeated root updates and a keeper; ONLY the contract owner may create them (the mutable root is a trusted-updater surface — see README threat model). Non-streaming (\"one-shot\") campaigns are auto-frozen on their first root publish, so a permissionless creator can never republish over already-funded float. This split is the core of the contract's safety model.",
+              "type": "boolean"
+            },
+            "swept": {
+              "type": "boolean"
+            },
+            "total": {
+              "description": "Declared sum of all leaf amounts under `root`. The contract cannot see the leaves, so honesty here is the publisher's responsibility; claims are hard-capped at `total - claimed_total` regardless, which confines a dishonest tree to its own campaign's balance.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "CampaignResponse": {
+          "type": "object",
+          "required": [
+            "campaign",
+            "id",
+            "remaining"
+          ],
+          "properties": {
+            "campaign": {
+              "$ref": "#/definitions/Campaign"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "remaining": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        },
+        "HexBinary": {
+          "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "claimable": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ClaimableResponse",
+      "type": "object",
+      "required": [
+        "payable",
+        "valid"
+      ],
+      "properties": {
+        "payable": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "valid": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "claimed": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ClaimedResponse",
+      "type": "object",
+      "required": [
+        "claimed"
+      ],
+      "properties": {
+        "claimed": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "claims": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ClaimsResponse",
+      "type": "object",
+      "required": [
+        "claims"
+      ],
+      "properties": {
+        "claims": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClaimEntry"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "ClaimEntry": {
+          "type": "object",
+          "required": [
+            "address",
+            "claimed"
+          ],
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/Addr"
+            },
+            "claimed": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "config": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Config",
+      "type": "object",
+      "required": [
+        "fee_bps",
+        "fee_collector",
+        "owner",
+        "paused"
+      ],
+      "properties": {
+        "fee_bps": {
+          "description": "Platform fee in basis points, charged ON TOP of every funding delta and forwarded to `fee_collector`. The campaign always retains exactly its declared delta, so the fee never eats into claimants' allocations.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        },
+        "fee_collector": {
+          "$ref": "#/definitions/Addr"
+        },
+        "owner": {
+          "$ref": "#/definitions/Addr"
+        },
+        "paused": {
+          "description": "Emergency stop: blocks create / update_root / claim / clawback.",
+          "type": "boolean"
+        },
+        "pending_owner": {
+          "description": "Two-step ownership transfer: a proposed owner who must `AcceptOwnership` before the transfer takes effect, so a typo can never brick control.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    },
+    "funding_required": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "FundingRequiredResponse",
+      "type": "object",
+      "required": [
+        "delta",
+        "denom",
+        "fee",
+        "required"
+      ],
+      "properties": {
+        "delta": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        },
+        "fee": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "required": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "liabilities": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "LiabilitiesResponse",
+      "type": "object",
+      "required": [
+        "owed"
+      ],
+      "properties": {
+        "owed": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/execute.json
+++ b/contracts/choice_claim_drops/schema/raw/execute.json
@@ -1,0 +1,559 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "description": "Open a new campaign.\n\n`streaming` campaigns accept repeated `UpdateRoot`s and a keeper, and may ONLY be created by the contract owner. A non-owner (or `streaming:false`) creates a one-shot: it is auto-frozen on its first published root, so its already-funded float can never be reassigned by a later republish.\n\nPass `initial` to publish the first root in the same tx (attach `total + fee`); omit it (no funds) to publish later via `UpdateRoot`.",
+      "type": "object",
+      "required": [
+        "create_campaign"
+      ],
+      "properties": {
+        "create_campaign": {
+          "type": "object",
+          "required": [
+            "denom",
+            "meta",
+            "streaming"
+          ],
+          "properties": {
+            "denom": {
+              "type": "string"
+            },
+            "expiry": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Timestamp"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "initial": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/InitialRoot"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "keeper": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "meta": {
+              "type": "string"
+            },
+            "streaming": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Publish (or, for streaming campaigns, replace) the merkle root of lifetime cumulative allocations. `total` may only rise; attach exactly `total - previous_total` plus the platform fee on that delta. Creator or keeper. A one-shot campaign is auto-frozen after this call.",
+      "type": "object",
+      "required": [
+        "update_root"
+      ],
+      "properties": {
+        "update_root": {
+          "type": "object",
+          "required": [
+            "id",
+            "leaves_uri",
+            "root",
+            "total"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "leaves_uri": {
+              "type": "string"
+            },
+            "root": {
+              "$ref": "#/definitions/HexBinary"
+            },
+            "total": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "One-way: permanently lock the root, and (if perpetual) the expiry policy. Auto-invoked on a one-shot's first publish; the owner may also call it on a streaming campaign to end it.",
+      "type": "object",
+      "required": [
+        "freeze"
+      ],
+      "properties": {
+        "freeze": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Claim `amount − already_claimed`, where `amount` is the sender's cumulative leaf value proven against the current or previous root.",
+      "type": "object",
+      "required": [
+        "claim"
+      ],
+      "properties": {
+        "claim": {
+          "type": "object",
+          "required": [
+            "amount",
+            "id",
+            "proof"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "proof": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HexBinary"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Claim across several campaigns in one tx (portfolio \"claim all\"). `allow_partial` (default false): when true, individual claims that would fail (paused / expired / already-claimed) are skipped rather than reverting the whole tx; errors only if every claim is skipped.",
+      "type": "object",
+      "required": [
+        "claim_many"
+      ],
+      "properties": {
+        "claim_many": {
+          "type": "object",
+          "required": [
+            "claims"
+          ],
+          "properties": {
+            "allow_partial": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "claims": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ClaimMsg"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "After expiry the creator sweeps whatever was never claimed.",
+      "type": "object",
+      "required": [
+        "clawback"
+      ],
+      "properties": {
+        "clawback": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Recover tokens sent to the contract outside campaign accounting (wrong address, wrong denom). Owner-only; capped at `balance − liabilities` so it can never touch funds owed to claimants. Defaults: sweep all excess to the owner.",
+      "type": "object",
+      "required": [
+        "rescue"
+      ],
+      "properties": {
+        "rescue": {
+          "type": "object",
+          "required": [
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "denom": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Two-step ownership transfer (propose → accept).",
+      "type": "object",
+      "required": [
+        "transfer_ownership"
+      ],
+      "properties": {
+        "transfer_ownership": {
+          "type": "object",
+          "required": [
+            "new_owner"
+          ],
+          "properties": {
+            "new_owner": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "accept_ownership"
+      ],
+      "properties": {
+        "accept_ownership": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Two-step per-campaign creator transfer (rotate a creator key).",
+      "type": "object",
+      "required": [
+        "transfer_creator"
+      ],
+      "properties": {
+        "transfer_creator": {
+          "type": "object",
+          "required": [
+            "id",
+            "new_creator"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "new_creator": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "accept_creator"
+      ],
+      "properties": {
+        "accept_creator": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "set_keeper"
+      ],
+      "properties": {
+        "set_keeper": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "keeper": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Extend an expiry, or wind down a perpetual campaign with ≥7 days notice. A frozen perpetual campaign's expiry is locked.",
+      "type": "object",
+      "required": [
+        "set_expiry"
+      ],
+      "properties": {
+        "set_expiry": {
+          "type": "object",
+          "required": [
+            "expiry",
+            "id"
+          ],
+          "properties": {
+            "expiry": {
+              "$ref": "#/definitions/Timestamp"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "set_campaign_paused"
+      ],
+      "properties": {
+        "set_campaign_paused": {
+          "type": "object",
+          "required": [
+            "id",
+            "paused"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "paused": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_meta"
+      ],
+      "properties": {
+        "update_meta": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "leaves_uri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "meta": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Owner config. Ownership is transferred via the two-step flow, not here.",
+      "type": "object",
+      "required": [
+        "update_config"
+      ],
+      "properties": {
+        "update_config": {
+          "type": "object",
+          "properties": {
+            "fee_bps": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint16",
+              "minimum": 0.0
+            },
+            "fee_collector": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "paused": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "ClaimMsg": {
+      "type": "object",
+      "required": [
+        "amount",
+        "id",
+        "proof"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "proof": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HexBinary"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "HexBinary": {
+      "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "InitialRoot": {
+      "description": "A root published atomically with `CreateCampaign` — lets a one-shot drop be created, funded, and (being non-streaming) auto-frozen in a single tx, so the claim link is never shareable before the root is immutable. Attach exactly `total + fee`.",
+      "type": "object",
+      "required": [
+        "leaves_uri",
+        "root",
+        "total"
+      ],
+      "properties": {
+        "leaves_uri": {
+          "type": "string"
+        },
+        "root": {
+          "$ref": "#/definitions/HexBinary"
+        },
+        "total": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/instantiate.json
+++ b/contracts/choice_claim_drops/schema/raw/instantiate.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "fee_bps"
+  ],
+  "properties": {
+    "fee_bps": {
+      "description": "Platform fee in bps charged on top of funding deltas. Capped at 1000 (10%).",
+      "type": "integer",
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "fee_collector": {
+      "description": "Defaults to the owner.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "owner": {
+      "description": "Defaults to the instantiator.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/choice_claim_drops/schema/raw/migrate.json
+++ b/contracts/choice_claim_drops/schema/raw/migrate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "type": "object",
+  "additionalProperties": false
+}

--- a/contracts/choice_claim_drops/schema/raw/query.json
+++ b/contracts/choice_claim_drops/schema/raw/query.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "campaign"
+      ],
+      "properties": {
+        "campaign": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "campaigns"
+      ],
+      "properties": {
+        "campaigns": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "campaigns_by_creator"
+      ],
+      "properties": {
+        "campaigns_by_creator": {
+          "type": "object",
+          "required": [
+            "creator"
+          ],
+          "properties": {
+            "creator": {
+              "type": "string"
+            },
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "claimed"
+      ],
+      "properties": {
+        "claimed": {
+          "type": "object",
+          "required": [
+            "address",
+            "id"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Paginated list of a campaign's claimants + their cumulative claimed amounts. Powers the trippytools manage view without an off-chain indexer.",
+      "type": "object",
+      "required": [
+        "claims"
+      ],
+      "properties": {
+        "claims": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Dry-run a claim: proof validity plus the payable amount right now (zero when the campaign is paused, expired, swept, or exhausted).",
+      "type": "object",
+      "required": [
+        "claimable"
+      ],
+      "properties": {
+        "claimable": {
+          "type": "object",
+          "required": [
+            "address",
+            "amount",
+            "id",
+            "proof"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "proof": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/HexBinary"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Exact funds to attach to move a campaign's declared total to `new_total`, so integrators never have to replicate the fee rounding.",
+      "type": "object",
+      "required": [
+        "funding_required"
+      ],
+      "properties": {
+        "funding_required": {
+          "type": "object",
+          "required": [
+            "id",
+            "new_total"
+          ],
+          "properties": {
+            "id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "new_total": {
+              "$ref": "#/definitions/Uint128"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Amount currently owed to claimants for a denom (Σ remaining across its campaigns). Reconcile against the contract's bank balance.",
+      "type": "object",
+      "required": [
+        "liabilities"
+      ],
+      "properties": {
+        "liabilities": {
+          "type": "object",
+          "required": [
+            "denom"
+          ],
+          "properties": {
+            "denom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "HexBinary": {
+      "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_campaign.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_campaign.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CampaignResponse",
+  "type": "object",
+  "required": [
+    "campaign",
+    "id",
+    "remaining"
+  ],
+  "properties": {
+    "campaign": {
+      "$ref": "#/definitions/Campaign"
+    },
+    "id": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "remaining": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Campaign": {
+      "type": "object",
+      "required": [
+        "claimants",
+        "claimed_total",
+        "creator",
+        "denom",
+        "frozen",
+        "leaves_uri",
+        "meta",
+        "paused",
+        "prev_total",
+        "streaming",
+        "swept",
+        "total"
+      ],
+      "properties": {
+        "claimants": {
+          "description": "Count of distinct addresses that have claimed at least once (manage-view stat; avoids paginating every claimant just to count).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "claimed_total": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "creator": {
+          "$ref": "#/definitions/Addr"
+        },
+        "denom": {
+          "description": "Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).",
+          "type": "string"
+        },
+        "expiry": {
+          "description": "After expiry claims stop and the creator may claw back the remainder. `None` = perpetual.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "frozen": {
+          "description": "One-way switch blocking all future root updates. Auto-set on a one-shot campaign's first publish; the owner may also set it on a streaming campaign to end it. Also locks the expiry policy (a frozen perpetual drop can never be given an expiry, so it can never be clawed back).",
+          "type": "boolean"
+        },
+        "keeper": {
+          "description": "Optional second address allowed to publish roots — the rewards keeper bot for streaming campaigns. Only meaningful when `streaming`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "leaves_uri": {
+          "description": "Where the full `(address, cumulative_amount)` leaves file for `root` is published. Clients rebuild the tree from it and derive their own proofs; it doubles as the public audit record of the campaign.",
+          "type": "string"
+        },
+        "meta": {
+          "description": "Free-form JSON rendered by frontends (title, logo, description).",
+          "type": "string"
+        },
+        "paused": {
+          "type": "boolean"
+        },
+        "pending_creator": {
+          "description": "Two-step creator transfer target (rotate a lost/compromised creator key without stranding the campaign's clawback + admin powers).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prev_root": {
+          "description": "The previous root stays claimable after an update so proofs fetched just before a keeper publish don't race to failure. Safe under cumulative semantics: an old leaf only ever claims less.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HexBinary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prev_total": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "root": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HexBinary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "streaming": {
+          "description": "Streaming campaigns accept repeated root updates and a keeper; ONLY the contract owner may create them (the mutable root is a trusted-updater surface — see README threat model). Non-streaming (\"one-shot\") campaigns are auto-frozen on their first root publish, so a permissionless creator can never republish over already-funded float. This split is the core of the contract's safety model.",
+          "type": "boolean"
+        },
+        "swept": {
+          "type": "boolean"
+        },
+        "total": {
+          "description": "Declared sum of all leaf amounts under `root`. The contract cannot see the leaves, so honesty here is the publisher's responsibility; claims are hard-capped at `total - claimed_total` regardless, which confines a dishonest tree to its own campaign's balance.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HexBinary": {
+      "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_campaigns.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_campaigns.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Array_of_CampaignResponse",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/CampaignResponse"
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Campaign": {
+      "type": "object",
+      "required": [
+        "claimants",
+        "claimed_total",
+        "creator",
+        "denom",
+        "frozen",
+        "leaves_uri",
+        "meta",
+        "paused",
+        "prev_total",
+        "streaming",
+        "swept",
+        "total"
+      ],
+      "properties": {
+        "claimants": {
+          "description": "Count of distinct addresses that have claimed at least once (manage-view stat; avoids paginating every claimant just to count).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "claimed_total": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "creator": {
+          "$ref": "#/definitions/Addr"
+        },
+        "denom": {
+          "description": "Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).",
+          "type": "string"
+        },
+        "expiry": {
+          "description": "After expiry claims stop and the creator may claw back the remainder. `None` = perpetual.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "frozen": {
+          "description": "One-way switch blocking all future root updates. Auto-set on a one-shot campaign's first publish; the owner may also set it on a streaming campaign to end it. Also locks the expiry policy (a frozen perpetual drop can never be given an expiry, so it can never be clawed back).",
+          "type": "boolean"
+        },
+        "keeper": {
+          "description": "Optional second address allowed to publish roots — the rewards keeper bot for streaming campaigns. Only meaningful when `streaming`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "leaves_uri": {
+          "description": "Where the full `(address, cumulative_amount)` leaves file for `root` is published. Clients rebuild the tree from it and derive their own proofs; it doubles as the public audit record of the campaign.",
+          "type": "string"
+        },
+        "meta": {
+          "description": "Free-form JSON rendered by frontends (title, logo, description).",
+          "type": "string"
+        },
+        "paused": {
+          "type": "boolean"
+        },
+        "pending_creator": {
+          "description": "Two-step creator transfer target (rotate a lost/compromised creator key without stranding the campaign's clawback + admin powers).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prev_root": {
+          "description": "The previous root stays claimable after an update so proofs fetched just before a keeper publish don't race to failure. Safe under cumulative semantics: an old leaf only ever claims less.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HexBinary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prev_total": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "root": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HexBinary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "streaming": {
+          "description": "Streaming campaigns accept repeated root updates and a keeper; ONLY the contract owner may create them (the mutable root is a trusted-updater surface — see README threat model). Non-streaming (\"one-shot\") campaigns are auto-frozen on their first root publish, so a permissionless creator can never republish over already-funded float. This split is the core of the contract's safety model.",
+          "type": "boolean"
+        },
+        "swept": {
+          "type": "boolean"
+        },
+        "total": {
+          "description": "Declared sum of all leaf amounts under `root`. The contract cannot see the leaves, so honesty here is the publisher's responsibility; claims are hard-capped at `total - claimed_total` regardless, which confines a dishonest tree to its own campaign's balance.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CampaignResponse": {
+      "type": "object",
+      "required": [
+        "campaign",
+        "id",
+        "remaining"
+      ],
+      "properties": {
+        "campaign": {
+          "$ref": "#/definitions/Campaign"
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "remaining": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HexBinary": {
+      "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_campaigns_by_creator.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_campaigns_by_creator.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Array_of_CampaignResponse",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/CampaignResponse"
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Campaign": {
+      "type": "object",
+      "required": [
+        "claimants",
+        "claimed_total",
+        "creator",
+        "denom",
+        "frozen",
+        "leaves_uri",
+        "meta",
+        "paused",
+        "prev_total",
+        "streaming",
+        "swept",
+        "total"
+      ],
+      "properties": {
+        "claimants": {
+          "description": "Count of distinct addresses that have claimed at least once (manage-view stat; avoids paginating every claimant just to count).",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "claimed_total": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "creator": {
+          "$ref": "#/definitions/Addr"
+        },
+        "denom": {
+          "description": "Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).",
+          "type": "string"
+        },
+        "expiry": {
+          "description": "After expiry claims stop and the creator may claw back the remainder. `None` = perpetual.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Timestamp"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "frozen": {
+          "description": "One-way switch blocking all future root updates. Auto-set on a one-shot campaign's first publish; the owner may also set it on a streaming campaign to end it. Also locks the expiry policy (a frozen perpetual drop can never be given an expiry, so it can never be clawed back).",
+          "type": "boolean"
+        },
+        "keeper": {
+          "description": "Optional second address allowed to publish roots — the rewards keeper bot for streaming campaigns. Only meaningful when `streaming`.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "leaves_uri": {
+          "description": "Where the full `(address, cumulative_amount)` leaves file for `root` is published. Clients rebuild the tree from it and derive their own proofs; it doubles as the public audit record of the campaign.",
+          "type": "string"
+        },
+        "meta": {
+          "description": "Free-form JSON rendered by frontends (title, logo, description).",
+          "type": "string"
+        },
+        "paused": {
+          "type": "boolean"
+        },
+        "pending_creator": {
+          "description": "Two-step creator transfer target (rotate a lost/compromised creator key without stranding the campaign's clawback + admin powers).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prev_root": {
+          "description": "The previous root stays claimable after an update so proofs fetched just before a keeper publish don't race to failure. Safe under cumulative semantics: an old leaf only ever claims less.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HexBinary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prev_total": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "root": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/HexBinary"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "streaming": {
+          "description": "Streaming campaigns accept repeated root updates and a keeper; ONLY the contract owner may create them (the mutable root is a trusted-updater surface — see README threat model). Non-streaming (\"one-shot\") campaigns are auto-frozen on their first root publish, so a permissionless creator can never republish over already-funded float. This split is the core of the contract's safety model.",
+          "type": "boolean"
+        },
+        "swept": {
+          "type": "boolean"
+        },
+        "total": {
+          "description": "Declared sum of all leaf amounts under `root`. The contract cannot see the leaves, so honesty here is the publisher's responsibility; claims are hard-capped at `total - claimed_total` regardless, which confines a dishonest tree to its own campaign's balance.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CampaignResponse": {
+      "type": "object",
+      "required": [
+        "campaign",
+        "id",
+        "remaining"
+      ],
+      "properties": {
+        "campaign": {
+          "$ref": "#/definitions/Campaign"
+        },
+        "id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "remaining": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "HexBinary": {
+      "description": "This is a wrapper around Vec<u8> to add hex de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is similar to `cosmwasm_std::Binary` but uses hex. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_claimable.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_claimable.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ClaimableResponse",
+  "type": "object",
+  "required": [
+    "payable",
+    "valid"
+  ],
+  "properties": {
+    "payable": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "valid": {
+      "type": "boolean"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_claimed.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_claimed.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ClaimedResponse",
+  "type": "object",
+  "required": [
+    "claimed"
+  ],
+  "properties": {
+    "claimed": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_claims.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_claims.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ClaimsResponse",
+  "type": "object",
+  "required": [
+    "claims"
+  ],
+  "properties": {
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ClaimEntry"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "ClaimEntry": {
+      "type": "object",
+      "required": [
+        "address",
+        "claimed"
+      ],
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/Addr"
+        },
+        "claimed": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_config.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_config.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config",
+  "type": "object",
+  "required": [
+    "fee_bps",
+    "fee_collector",
+    "owner",
+    "paused"
+  ],
+  "properties": {
+    "fee_bps": {
+      "description": "Platform fee in basis points, charged ON TOP of every funding delta and forwarded to `fee_collector`. The campaign always retains exactly its declared delta, so the fee never eats into claimants' allocations.",
+      "type": "integer",
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "fee_collector": {
+      "$ref": "#/definitions/Addr"
+    },
+    "owner": {
+      "$ref": "#/definitions/Addr"
+    },
+    "paused": {
+      "description": "Emergency stop: blocks create / update_root / claim / clawback.",
+      "type": "boolean"
+    },
+    "pending_owner": {
+      "description": "Two-step ownership transfer: a proposed owner who must `AcceptOwnership` before the transfer takes effect, so a typo can never brick control.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_funding_required.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_funding_required.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FundingRequiredResponse",
+  "type": "object",
+  "required": [
+    "delta",
+    "denom",
+    "fee",
+    "required"
+  ],
+  "properties": {
+    "delta": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "denom": {
+      "type": "string"
+    },
+    "fee": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "required": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/schema/raw/response_to_liabilities.json
+++ b/contracts/choice_claim_drops/schema/raw/response_to_liabilities.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LiabilitiesResponse",
+  "type": "object",
+  "required": [
+    "owed"
+  ],
+  "properties": {
+    "owed": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/choice_claim_drops/src/contract.rs
+++ b/contracts/choice_claim_drops/src/contract.rs
@@ -1,0 +1,1116 @@
+use cosmwasm_std::{
+    entry_point, to_json_binary, Addr, BankMsg, Binary, Coin, Deps, DepsMut, Env, Event, HexBinary,
+    MessageInfo, Order, Response, StdError, StdResult, Storage, Timestamp, Uint128, Uint256,
+};
+use cw_storage_plus::Bound;
+
+use crate::error::ContractError;
+use crate::merkle;
+use crate::msg::{
+    CampaignResponse, ClaimEntry, ClaimMsg, ClaimableResponse, ClaimedResponse, ClaimsResponse,
+    ExecuteMsg, FundingRequiredResponse, InitialRoot, InstantiateMsg, LiabilitiesResponse,
+    MigrateMsg, QueryMsg,
+};
+use crate::state::{
+    Campaign, Config, CAMPAIGNS, CAMPAIGN_SEQ, CLAIMED, CONFIG, CREATOR_CAMPAIGNS, LIABILITIES,
+};
+
+const CONTRACT_NAME: &str = "crates.io:choice-claim-drops";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const MAX_FEE_BPS: u16 = 1_000;
+/// Winding down a perpetual campaign (expiry None -> Some) needs this much
+/// notice so a creator can't set expiry to "now" and immediately claw back
+/// funds a published root promised to recipients.
+const MIN_WIND_DOWN_SECONDS: u64 = 7 * 24 * 60 * 60;
+/// 2^64 leaves is beyond any realistic tree; longer proofs are malformed.
+const MAX_PROOF_LEN: usize = 64;
+/// `meta` is re-serialized on every claim (it rides on the Campaign struct), so
+/// keep it small; large blobs belong off-chain behind `leaves_uri`.
+const MAX_META_LEN: usize = 4_096;
+const MAX_LEAVES_URI_LEN: usize = 512;
+
+const DEFAULT_LIMIT: u32 = 30;
+const MAX_LIMIT: u32 = 100;
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    if msg.fee_bps > MAX_FEE_BPS {
+        return Err(ContractError::FeeTooHigh { max: MAX_FEE_BPS });
+    }
+    let owner = match msg.owner {
+        Some(o) => deps.api.addr_validate(&o)?,
+        None => info.sender,
+    };
+    let fee_collector = match msg.fee_collector {
+        Some(c) => deps.api.addr_validate(&c)?,
+        None => owner.clone(),
+    };
+
+    CONFIG.save(
+        deps.storage,
+        &Config {
+            owner,
+            pending_owner: None,
+            fee_bps: msg.fee_bps,
+            fee_collector,
+            paused: false,
+        },
+    )?;
+    CAMPAIGN_SEQ.save(deps.storage, &0u64)?;
+
+    Ok(Response::new().add_attribute("action", "instantiate"))
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+
+    // The emergency stop halts everything that moves funds or creates new
+    // obligations. Campaign administration and ownership/config stay available
+    // so the owner can un-pause and rotate keys.
+    if config.paused {
+        match &msg {
+            ExecuteMsg::CreateCampaign { .. }
+            | ExecuteMsg::UpdateRoot { .. }
+            | ExecuteMsg::Claim { .. }
+            | ExecuteMsg::ClaimMany { .. }
+            | ExecuteMsg::Clawback { .. }
+            | ExecuteMsg::Rescue { .. } => return Err(ContractError::Paused),
+            _ => {}
+        }
+    }
+
+    match msg {
+        ExecuteMsg::CreateCampaign {
+            denom,
+            meta,
+            keeper,
+            expiry,
+            streaming,
+            initial,
+        } => create_campaign(
+            deps, env, info, &config, denom, meta, keeper, expiry, streaming, initial,
+        ),
+        ExecuteMsg::UpdateRoot {
+            id,
+            root,
+            total,
+            leaves_uri,
+        } => update_root(deps, env, info, &config, id, root, total, leaves_uri),
+        ExecuteMsg::Freeze { id } => freeze(deps, info, id),
+        ExecuteMsg::Claim { id, amount, proof } => {
+            let (payout, denom) = apply_claim(
+                deps.storage,
+                env.block.time,
+                id,
+                &info.sender,
+                amount,
+                &proof,
+            )?;
+            Ok(Response::new()
+                .add_message(BankMsg::Send {
+                    to_address: info.sender.to_string(),
+                    amount: vec![Coin {
+                        denom: denom.clone(),
+                        amount: payout,
+                    }],
+                })
+                .add_event(claim_event(id, &info.sender, amount, payout, &denom))
+                .add_attribute("action", "claim"))
+        }
+        ExecuteMsg::ClaimMany {
+            claims,
+            allow_partial,
+        } => claim_many(deps, env, info, claims, allow_partial.unwrap_or(false)),
+        ExecuteMsg::Clawback { id } => clawback(deps, env, info, id),
+        ExecuteMsg::Rescue {
+            denom,
+            amount,
+            recipient,
+        } => rescue(deps, env, info, &config, denom, amount, recipient),
+        ExecuteMsg::TransferOwnership { new_owner } => {
+            transfer_ownership(deps, info, config, new_owner)
+        }
+        ExecuteMsg::AcceptOwnership {} => accept_ownership(deps, info, config),
+        ExecuteMsg::TransferCreator { id, new_creator } => {
+            transfer_creator(deps, info, id, new_creator)
+        }
+        ExecuteMsg::AcceptCreator { id } => accept_creator(deps, info, id),
+        ExecuteMsg::SetKeeper { id, keeper } => set_keeper(deps, info, id, keeper),
+        ExecuteMsg::SetExpiry { id, expiry } => set_expiry(deps, env, info, id, expiry),
+        ExecuteMsg::SetCampaignPaused { id, paused } => set_campaign_paused(deps, info, id, paused),
+        ExecuteMsg::UpdateMeta {
+            id,
+            meta,
+            leaves_uri,
+        } => update_meta(deps, info, id, meta, leaves_uri),
+        ExecuteMsg::UpdateConfig {
+            fee_bps,
+            fee_collector,
+            paused,
+        } => update_config(deps, info, config, fee_bps, fee_collector, paused),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_campaign(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    config: &Config,
+    denom: String,
+    meta: String,
+    keeper: Option<String>,
+    expiry: Option<Timestamp>,
+    streaming: bool,
+    initial: Option<InitialRoot>,
+) -> Result<Response, ContractError> {
+    if denom.trim().is_empty() {
+        return Err(ContractError::InvalidDenom);
+    }
+    if meta.len() > MAX_META_LEN {
+        return Err(ContractError::MetaTooLong { max: MAX_META_LEN });
+    }
+    // The permission split: only the owner may open a mutable-root (streaming)
+    // campaign; everyone else gets a one-shot that auto-freezes on publish.
+    if streaming && info.sender != config.owner {
+        return Err(ContractError::StreamingRequiresOwner);
+    }
+    let keeper = keeper.map(|k| deps.api.addr_validate(&k)).transpose()?;
+    if keeper.is_some() && !streaming {
+        return Err(ContractError::KeeperRequiresStreaming);
+    }
+    if let Some(exp) = expiry {
+        if exp <= env.block.time {
+            return Err(ContractError::InvalidExpiry {
+                reason: "expiry must be in the future".to_string(),
+            });
+        }
+    }
+    // Without an initial root the create carries no funds.
+    if initial.is_none() && !info.funds.is_empty() {
+        return Err(ContractError::UnexpectedFunds);
+    }
+
+    let id = CAMPAIGN_SEQ.load(deps.storage)? + 1;
+    CAMPAIGN_SEQ.save(deps.storage, &id)?;
+
+    let mut campaign = Campaign {
+        creator: info.sender.clone(),
+        pending_creator: None,
+        keeper,
+        streaming,
+        denom: denom.clone(),
+        meta,
+        leaves_uri: String::new(),
+        root: None,
+        total: Uint128::zero(),
+        prev_root: None,
+        prev_total: Uint128::zero(),
+        claimed_total: Uint128::zero(),
+        claimants: 0,
+        frozen: false,
+        expiry,
+        paused: false,
+        swept: false,
+    };
+    CREATOR_CAMPAIGNS.save(deps.storage, (&info.sender, id), &())?;
+
+    let mut res = Response::new()
+        .add_attribute("action", "create_campaign")
+        .add_attribute("id", id.to_string())
+        .add_attribute("creator", info.sender.as_str())
+        .add_attribute("denom", denom)
+        .add_attribute("streaming", streaming.to_string())
+        .add_attribute(
+            "keeper",
+            campaign
+                .keeper
+                .as_ref()
+                .map(|k| k.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        )
+        .add_attribute(
+            "expiry",
+            expiry
+                .map(|e| e.seconds().to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        );
+
+    if let Some(init) = initial {
+        let outcome = apply_root_update(
+            deps.storage,
+            &mut campaign,
+            config,
+            &info,
+            init.root,
+            init.total,
+            init.leaves_uri,
+            env.block.time,
+        )?;
+        // One-shot campaigns are immutable from their first publish.
+        if !streaming {
+            campaign.frozen = true;
+        }
+        res = res.add_event(outcome.event(id));
+        if let Some(msg) = outcome.fee_msg {
+            res = res.add_message(msg);
+        }
+    }
+
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(res.set_data(to_json_binary(&id)?))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update_root(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    config: &Config,
+    id: u64,
+    root: HexBinary,
+    total: Uint128,
+    leaves_uri: String,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+
+    let is_keeper = campaign.keeper.as_ref() == Some(&info.sender);
+    if info.sender != campaign.creator && !is_keeper {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let outcome = apply_root_update(
+        deps.storage,
+        &mut campaign,
+        config,
+        &info,
+        root,
+        total,
+        leaves_uri,
+        env.block.time,
+    )?;
+    // A one-shot gets exactly one root; auto-freeze so it can never be replaced.
+    if !campaign.streaming {
+        campaign.frozen = true;
+    }
+    let event = outcome.event(id);
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+
+    let mut res = Response::new().add_event(event);
+    if let Some(msg) = outcome.fee_msg {
+        res = res.add_message(msg);
+    }
+    Ok(res)
+}
+
+struct RootOutcome {
+    fee_msg: Option<BankMsg>,
+    root_hex: String,
+    total: Uint128,
+    delta: Uint128,
+    fee: Uint128,
+}
+
+impl RootOutcome {
+    fn event(&self, id: u64) -> Event {
+        Event::new("update_root")
+            .add_attribute("id", id.to_string())
+            .add_attribute("root", &self.root_hex)
+            .add_attribute("total", self.total)
+            .add_attribute("delta", self.delta)
+            .add_attribute("fee", self.fee)
+    }
+}
+
+/// Core of publishing a root: validates, enforces the exact-funding solvency
+/// invariant, rotates the previous root, books the liability, and returns the
+/// optional fee transfer. Shared by `CreateCampaign { initial }` and
+/// `UpdateRoot`. Does NOT check authorization or set `frozen` — callers do.
+#[allow(clippy::too_many_arguments)]
+fn apply_root_update(
+    storage: &mut dyn Storage,
+    campaign: &mut Campaign,
+    config: &Config,
+    info: &MessageInfo,
+    root: HexBinary,
+    total: Uint128,
+    leaves_uri: String,
+    now: Timestamp,
+) -> Result<RootOutcome, ContractError> {
+    if campaign.swept {
+        return Err(ContractError::Swept);
+    }
+    if campaign.frozen {
+        return Err(ContractError::Frozen);
+    }
+    if campaign.is_expired(now) {
+        return Err(ContractError::Expired);
+    }
+    if root.len() != 32 {
+        return Err(ContractError::InvalidRoot);
+    }
+    if leaves_uri.len() > MAX_LEAVES_URI_LEN {
+        return Err(ContractError::LeavesUriTooLong {
+            max: MAX_LEAVES_URI_LEN,
+        });
+    }
+    if total < campaign.total {
+        return Err(ContractError::TotalDecreased {
+            current: campaign.total,
+            new: total,
+        });
+    }
+
+    let delta = total.checked_sub(campaign.total).map_err(StdError::from)?;
+    // Fee is charged on top so the campaign always retains exactly `delta` and
+    // stays solvent for its declared total. Ceil so tiny deltas can't dodge it.
+    let fee = ceil_fee(delta, config.fee_bps)?;
+    let required = delta.checked_add(fee).map_err(StdError::from)?;
+    assert_exact_funds(info, &campaign.denom, required)?;
+
+    if campaign.root.is_some() {
+        campaign.prev_root = campaign.root.clone();
+        campaign.prev_total = campaign.total;
+    }
+    let root_hex = root.to_hex();
+    campaign.root = Some(root);
+    campaign.total = total;
+    campaign.leaves_uri = leaves_uri;
+
+    add_liability(storage, &campaign.denom, delta)?;
+
+    let fee_msg = if fee.is_zero() {
+        None
+    } else {
+        Some(BankMsg::Send {
+            to_address: config.fee_collector.to_string(),
+            amount: vec![Coin {
+                denom: campaign.denom.clone(),
+                amount: fee,
+            }],
+        })
+    };
+
+    Ok(RootOutcome {
+        fee_msg,
+        root_hex,
+        total,
+        delta,
+        fee,
+    })
+}
+
+fn freeze(deps: DepsMut, info: MessageInfo, id: u64) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    if campaign.root.is_none() {
+        return Err(ContractError::NoRoot);
+    }
+    campaign.frozen = true;
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(Response::new()
+        .add_attribute("action", "freeze")
+        .add_attribute("id", id.to_string()))
+}
+
+/// Shared claim core for Claim / ClaimMany. Verifies the proof against the
+/// current root, falling back to the previous one, pays the cumulative delta,
+/// and hard-caps every payout at the campaign's remaining declared funds so a
+/// dishonest tree can never touch another campaign's balance.
+fn apply_claim(
+    storage: &mut dyn Storage,
+    now: Timestamp,
+    id: u64,
+    sender: &Addr,
+    amount: Uint128,
+    proof: &[HexBinary],
+) -> Result<(Uint128, String), ContractError> {
+    let mut campaign = load_campaign(storage, id)?;
+    if campaign.paused {
+        return Err(ContractError::CampaignPaused);
+    }
+    if campaign.swept {
+        return Err(ContractError::Swept);
+    }
+    if campaign.is_expired(now) {
+        return Err(ContractError::Expired);
+    }
+    if proof.len() > MAX_PROOF_LEN {
+        return Err(ContractError::ProofTooLong);
+    }
+
+    let leaf = merkle::leaf_hash(sender.as_str(), amount);
+    let valid = campaign
+        .root
+        .as_ref()
+        .is_some_and(|r| merkle::verify(r.as_slice(), leaf, proof))
+        || campaign
+            .prev_root
+            .as_ref()
+            .is_some_and(|r| merkle::verify(r.as_slice(), leaf, proof));
+    if !valid {
+        return Err(ContractError::InvalidProof);
+    }
+
+    let claimed = CLAIMED.may_load(storage, (id, sender))?.unwrap_or_default();
+    if amount <= claimed {
+        return Err(ContractError::NothingToClaim);
+    }
+    let payout = amount.checked_sub(claimed).map_err(StdError::from)?;
+    if payout > campaign.remaining() {
+        return Err(ContractError::ExceedsCampaignFunds);
+    }
+
+    if claimed.is_zero() {
+        campaign.claimants += 1;
+    }
+    CLAIMED.save(storage, (id, sender), &amount)?;
+    campaign.claimed_total = campaign
+        .claimed_total
+        .checked_add(payout)
+        .map_err(StdError::from)?;
+    let denom = campaign.denom.clone();
+    CAMPAIGNS.save(storage, id, &campaign)?;
+    sub_liability(storage, &denom, payout)?;
+    Ok((payout, denom))
+}
+
+fn claim_many(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    claims: Vec<ClaimMsg>,
+    allow_partial: bool,
+) -> Result<Response, ContractError> {
+    if claims.is_empty() {
+        return Err(ContractError::NothingToClaim);
+    }
+    let mut res = Response::new()
+        .add_attribute("action", "claim_many")
+        .add_attribute("claimant", info.sender.as_str());
+    let mut paid_any = false;
+    for c in claims {
+        match apply_claim(
+            deps.storage,
+            env.block.time,
+            c.id,
+            &info.sender,
+            c.amount,
+            &c.proof,
+        ) {
+            Ok((payout, denom)) => {
+                paid_any = true;
+                res = res
+                    .add_message(BankMsg::Send {
+                        to_address: info.sender.to_string(),
+                        amount: vec![Coin {
+                            denom: denom.clone(),
+                            amount: payout,
+                        }],
+                    })
+                    .add_event(claim_event(c.id, &info.sender, c.amount, payout, &denom));
+            }
+            Err(e) if allow_partial => {
+                res = res.add_event(
+                    Event::new("claim_skipped")
+                        .add_attribute("id", c.id.to_string())
+                        .add_attribute("reason", e.to_string()),
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    if !paid_any {
+        return Err(ContractError::NothingToClaim);
+    }
+    Ok(res)
+}
+
+fn clawback(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    id: u64,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    if campaign.swept {
+        return Err(ContractError::Swept);
+    }
+    if !campaign.is_expired(env.block.time) {
+        return Err(ContractError::NotExpired);
+    }
+
+    let remaining = campaign.remaining();
+    campaign.swept = true;
+    let denom = campaign.denom.clone();
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    sub_liability(deps.storage, &denom, remaining)?;
+
+    let mut res = Response::new()
+        .add_attribute("action", "clawback")
+        .add_attribute("id", id.to_string())
+        .add_attribute("amount", remaining);
+    if !remaining.is_zero() {
+        res = res.add_message(BankMsg::Send {
+            to_address: campaign.creator.to_string(),
+            amount: vec![Coin {
+                denom,
+                amount: remaining,
+            }],
+        });
+    }
+    Ok(res)
+}
+
+fn rescue(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    config: &Config,
+    denom: String,
+    amount: Option<Uint128>,
+    recipient: Option<String>,
+) -> Result<Response, ContractError> {
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+    let balance = deps
+        .querier
+        .query_balance(&env.contract.address, &denom)?
+        .amount;
+    let owed = LIABILITIES
+        .may_load(deps.storage, &denom)?
+        .unwrap_or_default();
+    // Everything above what claimants are owed is unencumbered.
+    let excess = balance.saturating_sub(owed);
+    let send = match amount {
+        Some(a) => {
+            if a > excess {
+                return Err(ContractError::RescueExceedsExcess { available: excess });
+            }
+            a
+        }
+        None => excess,
+    };
+    if send.is_zero() {
+        return Err(ContractError::NothingToRescue);
+    }
+    let to = match recipient {
+        Some(r) => deps.api.addr_validate(&r)?,
+        None => config.owner.clone(),
+    };
+    Ok(Response::new()
+        .add_message(BankMsg::Send {
+            to_address: to.to_string(),
+            amount: vec![Coin {
+                denom: denom.clone(),
+                amount: send,
+            }],
+        })
+        .add_attribute("action", "rescue")
+        .add_attribute("denom", denom)
+        .add_attribute("amount", send)
+        .add_attribute("recipient", to))
+}
+
+fn transfer_ownership(
+    deps: DepsMut,
+    info: MessageInfo,
+    mut config: Config,
+    new_owner: String,
+) -> Result<Response, ContractError> {
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+    let pending = deps.api.addr_validate(&new_owner)?;
+    config.pending_owner = Some(pending.clone());
+    CONFIG.save(deps.storage, &config)?;
+    Ok(Response::new()
+        .add_attribute("action", "transfer_ownership")
+        .add_attribute("pending_owner", pending))
+}
+
+fn accept_ownership(
+    deps: DepsMut,
+    info: MessageInfo,
+    mut config: Config,
+) -> Result<Response, ContractError> {
+    match &config.pending_owner {
+        Some(p) if *p == info.sender => {}
+        _ => return Err(ContractError::NoPendingOwnership),
+    }
+    config.owner = info.sender.clone();
+    config.pending_owner = None;
+    CONFIG.save(deps.storage, &config)?;
+    Ok(Response::new()
+        .add_attribute("action", "accept_ownership")
+        .add_attribute("owner", info.sender))
+}
+
+fn transfer_creator(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+    new_creator: String,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    let pending = deps.api.addr_validate(&new_creator)?;
+    campaign.pending_creator = Some(pending.clone());
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(Response::new()
+        .add_attribute("action", "transfer_creator")
+        .add_attribute("id", id.to_string())
+        .add_attribute("pending_creator", pending))
+}
+
+fn accept_creator(deps: DepsMut, info: MessageInfo, id: u64) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    match &campaign.pending_creator {
+        Some(p) if *p == info.sender => {}
+        _ => return Err(ContractError::NoPendingCreator),
+    }
+    let old_creator = campaign.creator.clone();
+    campaign.creator = info.sender.clone();
+    campaign.pending_creator = None;
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    // Move the CampaignsByCreator index entry to the new owner.
+    CREATOR_CAMPAIGNS.remove(deps.storage, (&old_creator, id));
+    CREATOR_CAMPAIGNS.save(deps.storage, (&info.sender, id), &())?;
+    Ok(Response::new()
+        .add_attribute("action", "accept_creator")
+        .add_attribute("id", id.to_string())
+        .add_attribute("creator", info.sender))
+}
+
+fn set_keeper(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+    keeper: Option<String>,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    if !campaign.streaming {
+        return Err(ContractError::NotStreaming);
+    }
+    campaign.keeper = keeper.map(|k| deps.api.addr_validate(&k)).transpose()?;
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(Response::new()
+        .add_attribute("action", "set_keeper")
+        .add_attribute("id", id.to_string())
+        .add_attribute(
+            "keeper",
+            campaign
+                .keeper
+                .as_ref()
+                .map(|k| k.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+        ))
+}
+
+fn set_expiry(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    id: u64,
+    expiry: Timestamp,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    if campaign.swept {
+        return Err(ContractError::Swept);
+    }
+    match campaign.expiry {
+        // Recipients can rely on an announced window: it only ever extends.
+        Some(current) => {
+            if expiry <= current {
+                return Err(ContractError::InvalidExpiry {
+                    reason: "expiry can only be extended".to_string(),
+                });
+            }
+        }
+        None => {
+            // A frozen perpetual drop promised no clawback; keep that promise.
+            if campaign.frozen {
+                return Err(ContractError::FrozenExpiryLocked);
+            }
+            if expiry < env.block.time.plus_seconds(MIN_WIND_DOWN_SECONDS) {
+                return Err(ContractError::InvalidExpiry {
+                    reason: "winding down a perpetual campaign requires at least 7 days notice"
+                        .to_string(),
+                });
+            }
+        }
+    }
+    campaign.expiry = Some(expiry);
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(Response::new()
+        .add_attribute("action", "set_expiry")
+        .add_attribute("id", id.to_string())
+        .add_attribute("expiry", expiry.seconds().to_string()))
+}
+
+fn set_campaign_paused(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+    paused: bool,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    campaign.paused = paused;
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(Response::new()
+        .add_attribute("action", "set_campaign_paused")
+        .add_attribute("id", id.to_string())
+        .add_attribute("paused", paused.to_string()))
+}
+
+fn update_meta(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+    meta: Option<String>,
+    leaves_uri: Option<String>,
+) -> Result<Response, ContractError> {
+    let mut campaign = load_campaign(deps.storage, id)?;
+    if info.sender != campaign.creator {
+        return Err(ContractError::Unauthorized);
+    }
+    let mut res = Response::new()
+        .add_attribute("action", "update_meta")
+        .add_attribute("id", id.to_string());
+    if let Some(m) = meta {
+        if m.len() > MAX_META_LEN {
+            return Err(ContractError::MetaTooLong { max: MAX_META_LEN });
+        }
+        campaign.meta = m;
+    }
+    if let Some(u) = leaves_uri {
+        if u.len() > MAX_LEAVES_URI_LEN {
+            return Err(ContractError::LeavesUriTooLong {
+                max: MAX_LEAVES_URI_LEN,
+            });
+        }
+        res = res.add_attribute("leaves_uri", &u);
+        campaign.leaves_uri = u;
+    }
+    CAMPAIGNS.save(deps.storage, id, &campaign)?;
+    Ok(res)
+}
+
+fn update_config(
+    deps: DepsMut,
+    info: MessageInfo,
+    mut config: Config,
+    fee_bps: Option<u16>,
+    fee_collector: Option<String>,
+    paused: Option<bool>,
+) -> Result<Response, ContractError> {
+    if info.sender != config.owner {
+        return Err(ContractError::Unauthorized);
+    }
+    let mut res = Response::new().add_attribute("action", "update_config");
+    if let Some(bps) = fee_bps {
+        if bps > MAX_FEE_BPS {
+            return Err(ContractError::FeeTooHigh { max: MAX_FEE_BPS });
+        }
+        config.fee_bps = bps;
+        res = res.add_attribute("fee_bps", bps.to_string());
+    }
+    if let Some(c) = fee_collector {
+        config.fee_collector = deps.api.addr_validate(&c)?;
+        res = res.add_attribute("fee_collector", c);
+    }
+    if let Some(p) = paused {
+        config.paused = p;
+        res = res.add_attribute("paused", p.to_string());
+    }
+    CONFIG.save(deps.storage, &config)?;
+    Ok(res)
+}
+
+// ---- helpers ----
+
+fn claim_event(
+    id: u64,
+    claimant: &Addr,
+    cumulative: Uint128,
+    payout: Uint128,
+    denom: &str,
+) -> Event {
+    Event::new("claim")
+        .add_attribute("id", id.to_string())
+        .add_attribute("claimant", claimant.as_str())
+        .add_attribute("cumulative", cumulative)
+        .add_attribute("payout", payout)
+        .add_attribute("denom", denom)
+}
+
+/// ceil(delta * fee_bps / 10_000). Ceil (not floor) so a large campaign can't
+/// be funded as many tiny deltas that each round the platform fee to zero.
+fn ceil_fee(delta: Uint128, fee_bps: u16) -> Result<Uint128, ContractError> {
+    if fee_bps == 0 || delta.is_zero() {
+        return Ok(Uint128::zero());
+    }
+    let denom = Uint256::from(10_000u128);
+    let num = Uint256::from(delta)
+        .checked_mul(Uint256::from(fee_bps as u128))
+        .map_err(StdError::from)?;
+    let ceil = num
+        .checked_add(denom.checked_sub(Uint256::one()).map_err(StdError::from)?)
+        .map_err(StdError::from)?
+        .checked_div(denom)
+        .map_err(StdError::from)?;
+    Ok(Uint128::try_from(ceil).map_err(StdError::from)?)
+}
+
+fn add_liability(storage: &mut dyn Storage, denom: &str, amount: Uint128) -> StdResult<()> {
+    LIABILITIES.update(storage, denom, |v| -> StdResult<_> {
+        v.unwrap_or_default()
+            .checked_add(amount)
+            .map_err(Into::into)
+    })?;
+    Ok(())
+}
+
+fn sub_liability(storage: &mut dyn Storage, denom: &str, amount: Uint128) -> StdResult<()> {
+    LIABILITIES.update(storage, denom, |v| -> StdResult<_> {
+        v.unwrap_or_default()
+            .checked_sub(amount)
+            .map_err(Into::into)
+    })?;
+    Ok(())
+}
+
+fn load_campaign(storage: &dyn Storage, id: u64) -> Result<Campaign, ContractError> {
+    CAMPAIGNS
+        .may_load(storage, id)?
+        .ok_or(ContractError::CampaignNotFound { id })
+}
+
+fn assert_exact_funds(
+    info: &MessageInfo,
+    denom: &str,
+    required: Uint128,
+) -> Result<(), ContractError> {
+    if required.is_zero() {
+        if info.funds.is_empty() {
+            return Ok(());
+        }
+        return Err(ContractError::UnexpectedFunds);
+    }
+    match info.funds.as_slice() {
+        [coin] if coin.denom == denom && coin.amount == required => Ok(()),
+        _ => Err(ContractError::InvalidFunds {
+            expected: required,
+            denom: denom.to_string(),
+        }),
+    }
+}
+
+#[entry_point]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Config {} => to_json_binary(&CONFIG.load(deps.storage)?),
+        QueryMsg::Campaign { id } => {
+            let campaign = CAMPAIGNS.load(deps.storage, id)?;
+            to_json_binary(&CampaignResponse {
+                id,
+                remaining: campaign.remaining(),
+                campaign,
+            })
+        }
+        QueryMsg::Campaigns { start_after, limit } => {
+            let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+            let start = start_after.map(Bound::exclusive);
+            let out: StdResult<Vec<_>> = CAMPAIGNS
+                .range(deps.storage, start, None, Order::Ascending)
+                .take(limit)
+                .map(|item| {
+                    let (id, campaign) = item?;
+                    Ok(CampaignResponse {
+                        id,
+                        remaining: campaign.remaining(),
+                        campaign,
+                    })
+                })
+                .collect();
+            to_json_binary(&out?)
+        }
+        QueryMsg::CampaignsByCreator {
+            creator,
+            start_after,
+            limit,
+        } => {
+            let creator = deps.api.addr_validate(&creator)?;
+            let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+            let start = start_after.map(Bound::exclusive);
+            let ids: StdResult<Vec<u64>> = CREATOR_CAMPAIGNS
+                .prefix(&creator)
+                .keys(deps.storage, start, None, Order::Ascending)
+                .take(limit)
+                .collect();
+            let out: StdResult<Vec<_>> = ids?
+                .into_iter()
+                .map(|id| {
+                    let campaign = CAMPAIGNS.load(deps.storage, id)?;
+                    Ok(CampaignResponse {
+                        id,
+                        remaining: campaign.remaining(),
+                        campaign,
+                    })
+                })
+                .collect();
+            to_json_binary(&out?)
+        }
+        QueryMsg::Claimed { id, address } => {
+            let addr = deps.api.addr_validate(&address)?;
+            let claimed = CLAIMED
+                .may_load(deps.storage, (id, &addr))?
+                .unwrap_or_default();
+            to_json_binary(&ClaimedResponse { claimed })
+        }
+        QueryMsg::Claims {
+            id,
+            start_after,
+            limit,
+        } => {
+            let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+            let start = start_after
+                .map(|s| deps.api.addr_validate(&s))
+                .transpose()?;
+            let bound = start.as_ref().map(Bound::exclusive);
+            let claims: StdResult<Vec<ClaimEntry>> = CLAIMED
+                .prefix(id)
+                .range(deps.storage, bound, None, Order::Ascending)
+                .take(limit)
+                .map(|item| {
+                    let (address, claimed) = item?;
+                    Ok(ClaimEntry { address, claimed })
+                })
+                .collect();
+            to_json_binary(&ClaimsResponse { claims: claims? })
+        }
+        QueryMsg::Claimable {
+            id,
+            address,
+            amount,
+            proof,
+        } => {
+            let addr = deps.api.addr_validate(&address)?;
+            let campaign = CAMPAIGNS.load(deps.storage, id)?;
+            let leaf = merkle::leaf_hash(addr.as_str(), amount);
+            let valid = proof.len() <= MAX_PROOF_LEN
+                && (campaign
+                    .root
+                    .as_ref()
+                    .is_some_and(|r| merkle::verify(r.as_slice(), leaf, &proof))
+                    || campaign
+                        .prev_root
+                        .as_ref()
+                        .is_some_and(|r| merkle::verify(r.as_slice(), leaf, &proof)));
+            let config = CONFIG.load(deps.storage)?;
+            let open = valid
+                && !config.paused
+                && !campaign.paused
+                && !campaign.swept
+                && !campaign.is_expired(env.block.time);
+            let payable = if open {
+                let claimed = CLAIMED
+                    .may_load(deps.storage, (id, &addr))?
+                    .unwrap_or_default();
+                amount
+                    .checked_sub(claimed)
+                    .unwrap_or_default()
+                    .min(campaign.remaining())
+            } else {
+                Uint128::zero()
+            };
+            to_json_binary(&ClaimableResponse { valid, payable })
+        }
+        QueryMsg::FundingRequired { id, new_total } => {
+            let campaign = CAMPAIGNS.load(deps.storage, id)?;
+            let delta = new_total.checked_sub(campaign.total).unwrap_or_default();
+            let fee = ceil_fee(delta, CONFIG.load(deps.storage)?.fee_bps)
+                .map_err(|e| StdError::generic_err(e.to_string()))?;
+            let required = delta.checked_add(fee)?;
+            to_json_binary(&FundingRequiredResponse {
+                delta,
+                fee,
+                required,
+                denom: campaign.denom,
+            })
+        }
+        QueryMsg::Liabilities { denom } => {
+            let owed = LIABILITIES
+                .may_load(deps.storage, &denom)?
+                .unwrap_or_default();
+            to_json_binary(&LiabilitiesResponse { owed })
+        }
+    }
+}
+
+#[entry_point]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let stored = cw2::get_contract_version(deps.storage)?;
+    if stored.contract != CONTRACT_NAME {
+        return Err(ContractError::Std(StdError::generic_err(format!(
+            "cannot migrate from {}",
+            stored.contract
+        ))));
+    }
+    // Refuse downgrades so a rollback can't silently reintroduce fixed bugs.
+    if let (Some(from), Some(to)) = (
+        parse_semver(&stored.version),
+        parse_semver(CONTRACT_VERSION),
+    ) {
+        if to < from {
+            return Err(ContractError::Std(StdError::generic_err(format!(
+                "cannot migrate down from {} to {}",
+                stored.version, CONTRACT_VERSION
+            ))));
+        }
+    }
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute("from", stored.version)
+        .add_attribute("to", CONTRACT_VERSION))
+}
+
+fn parse_semver(v: &str) -> Option<(u64, u64, u64)> {
+    let mut it = v.split('.');
+    let major = it.next()?.parse().ok()?;
+    let minor = it.next()?.parse().ok()?;
+    let patch = it.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}

--- a/contracts/choice_claim_drops/src/error.rs
+++ b/contracts/choice_claim_drops/src/error.rs
@@ -1,0 +1,98 @@
+use cosmwasm_std::{StdError, Uint128};
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("unauthorized")]
+    Unauthorized,
+
+    #[error("campaign {id} not found")]
+    CampaignNotFound { id: u64 },
+
+    #[error("contract is paused")]
+    Paused,
+
+    #[error("campaign is paused")]
+    CampaignPaused,
+
+    #[error("campaign is frozen; its root can no longer change")]
+    Frozen,
+
+    #[error("cannot freeze a campaign before its first root is published")]
+    NoRoot,
+
+    #[error("campaign has expired")]
+    Expired,
+
+    #[error("campaign has not expired yet")]
+    NotExpired,
+
+    #[error("campaign has already been swept")]
+    Swept,
+
+    #[error("declared total may not decrease (current {current}, new {new})")]
+    TotalDecreased { current: Uint128, new: Uint128 },
+
+    #[error("merkle root must be exactly 32 bytes")]
+    InvalidRoot,
+
+    #[error("merkle proof does not match the current or previous root")]
+    InvalidProof,
+
+    #[error("merkle proof too long")]
+    ProofTooLong,
+
+    #[error("nothing to claim")]
+    NothingToClaim,
+
+    #[error("claim exceeds campaign funds: the published tree over-allocates its declared total")]
+    ExceedsCampaignFunds,
+
+    #[error("must attach exactly {expected} {denom}")]
+    InvalidFunds { expected: Uint128, denom: String },
+
+    #[error("this message accepts no funds")]
+    UnexpectedFunds,
+
+    #[error("denom must not be empty")]
+    InvalidDenom,
+
+    #[error("invalid expiry: {reason}")]
+    InvalidExpiry { reason: String },
+
+    #[error("fee_bps may not exceed {max}")]
+    FeeTooHigh { max: u16 },
+
+    #[error("meta too long (max {max} bytes)")]
+    MetaTooLong { max: usize },
+
+    #[error("leaves_uri too long (max {max} bytes)")]
+    LeavesUriTooLong { max: usize },
+
+    #[error("streaming campaigns can only be created by the contract owner")]
+    StreamingRequiresOwner,
+
+    #[error("a keeper can only be set on a streaming campaign")]
+    KeeperRequiresStreaming,
+
+    #[error("this action requires a streaming campaign")]
+    NotStreaming,
+
+    #[error("no pending ownership transfer to accept")]
+    NoPendingOwnership,
+
+    #[error("no pending creator transfer to accept")]
+    NoPendingCreator,
+
+    #[error("a frozen perpetual campaign cannot be given an expiry")]
+    FrozenExpiryLocked,
+
+    #[error("nothing to rescue for this denom")]
+    NothingToRescue,
+
+    #[error("rescue exceeds unencumbered balance (available {available})")]
+    RescueExceedsExcess { available: Uint128 },
+}

--- a/contracts/choice_claim_drops/src/lib.rs
+++ b/contracts/choice_claim_drops/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod contract;
+pub mod error;
+pub mod merkle;
+pub mod msg;
+pub mod state;
+
+#[cfg(test)]
+mod testing;

--- a/contracts/choice_claim_drops/src/merkle.rs
+++ b/contracts/choice_claim_drops/src/merkle.rs
@@ -1,0 +1,90 @@
+use cosmwasm_std::{HexBinary, Uint128};
+use sha2::{Digest, Sha256};
+
+/// Cross-language leaf spec — any tree builder (TS keeper, trippytools FE)
+/// must reproduce these bytes exactly:
+///   leaf = sha256(utf8("{bech32_address}:{amount_base_units_decimal}"))
+/// The address is the claimant's canonical lowercase bech32 string; the amount
+/// is the LIFETIME CUMULATIVE allocation in base units, no separators.
+pub fn leaf_hash(addr: &str, amount: Uint128) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(addr.as_bytes());
+    h.update(b":");
+    h.update(amount.to_string().as_bytes());
+    h.finalize().into()
+}
+
+/// Sorted-pair (OpenZeppelin-style) verification: each parent hashes
+/// concat(min(a, b), max(a, b)), so proofs carry no left/right flags and an
+/// odd node at any level promotes unchanged (its proof simply omits that
+/// level). An empty proof means a single-leaf tree (leaf == root).
+pub fn verify(root: &[u8], mut node: [u8; 32], proof: &[HexBinary]) -> bool {
+    for step in proof {
+        let sib = step.as_slice();
+        if sib.len() != 32 {
+            return false;
+        }
+        let mut h = Sha256::new();
+        if node.as_slice() <= sib {
+            h.update(node);
+            h.update(sib);
+        } else {
+            h.update(sib);
+            h.update(node);
+        }
+        node = h.finalize().into();
+    }
+    node.as_slice() == root
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Golden vectors pinning the byte-level spec for other-language builders.
+    #[test]
+    fn leaf_hash_golden_vector() {
+        let leaf = leaf_hash(
+            "inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+            Uint128::new(1_000_000),
+        );
+        assert_eq!(
+            HexBinary::from(leaf).to_hex(),
+            "82021d82ef5d5a5db1fdf2b7204e4179da4676e67104d56464b03c767e16ce48"
+        );
+    }
+
+    #[test]
+    fn sorted_pair_golden_vector() {
+        // a = sha256("a-leaf-x"), b = sha256("b-leaf-y"); parent hashes the
+        // lexicographically smaller node first.
+        let a: [u8; 32] =
+            HexBinary::from_hex("7b631c0212ee9c2e8715fadd136a31706728c9cefa23cb42b681e0a5ec4792c5")
+                .unwrap()
+                .to_array()
+                .unwrap();
+        let b =
+            HexBinary::from_hex("079be04b5b153b7a84b4df326ad8d1f1f30fd5292cab32560dec512b5eb366c1")
+                .unwrap();
+        let parent =
+            HexBinary::from_hex("55a8565a798073b99f9332a82ce34227e834d115b9fa6639b348f687b820953a")
+                .unwrap();
+        assert!(verify(parent.as_slice(), a, &[b]));
+    }
+
+    #[test]
+    fn single_leaf_tree_is_its_own_root() {
+        let leaf = leaf_hash("inj1abc", Uint128::new(1));
+        assert!(verify(&leaf, leaf, &[]));
+    }
+
+    #[test]
+    fn rejects_malformed_sibling() {
+        let leaf = leaf_hash("inj1abc", Uint128::new(1));
+        assert!(!verify(
+            &leaf,
+            leaf,
+            &[HexBinary::from_hex("aabb").unwrap()]
+        ));
+    }
+}

--- a/contracts/choice_claim_drops/src/msg.rs
+++ b/contracts/choice_claim_drops/src/msg.rs
@@ -1,0 +1,227 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::{Addr, HexBinary, Timestamp, Uint128};
+
+use crate::state::Campaign;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    /// Defaults to the instantiator.
+    pub owner: Option<String>,
+    /// Platform fee in bps charged on top of funding deltas. Capped at 1000 (10%).
+    pub fee_bps: u16,
+    /// Defaults to the owner.
+    pub fee_collector: Option<String>,
+}
+
+/// A root published atomically with `CreateCampaign` — lets a one-shot drop be
+/// created, funded, and (being non-streaming) auto-frozen in a single tx, so
+/// the claim link is never shareable before the root is immutable. Attach
+/// exactly `total + fee`.
+#[cw_serde]
+pub struct InitialRoot {
+    pub root: HexBinary,
+    pub total: Uint128,
+    pub leaves_uri: String,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    /// Open a new campaign.
+    ///
+    /// `streaming` campaigns accept repeated `UpdateRoot`s and a keeper, and may
+    /// ONLY be created by the contract owner. A non-owner (or `streaming:false`)
+    /// creates a one-shot: it is auto-frozen on its first published root, so its
+    /// already-funded float can never be reassigned by a later republish.
+    ///
+    /// Pass `initial` to publish the first root in the same tx (attach
+    /// `total + fee`); omit it (no funds) to publish later via `UpdateRoot`.
+    CreateCampaign {
+        denom: String,
+        meta: String,
+        keeper: Option<String>,
+        expiry: Option<Timestamp>,
+        streaming: bool,
+        initial: Option<InitialRoot>,
+    },
+    /// Publish (or, for streaming campaigns, replace) the merkle root of
+    /// lifetime cumulative allocations. `total` may only rise; attach exactly
+    /// `total - previous_total` plus the platform fee on that delta. Creator or
+    /// keeper. A one-shot campaign is auto-frozen after this call.
+    UpdateRoot {
+        id: u64,
+        root: HexBinary,
+        total: Uint128,
+        leaves_uri: String,
+    },
+    /// One-way: permanently lock the root, and (if perpetual) the expiry policy.
+    /// Auto-invoked on a one-shot's first publish; the owner may also call it on
+    /// a streaming campaign to end it.
+    Freeze {
+        id: u64,
+    },
+    /// Claim `amount − already_claimed`, where `amount` is the sender's
+    /// cumulative leaf value proven against the current or previous root.
+    Claim {
+        id: u64,
+        amount: Uint128,
+        proof: Vec<HexBinary>,
+    },
+    /// Claim across several campaigns in one tx (portfolio "claim all").
+    /// `allow_partial` (default false): when true, individual claims that would
+    /// fail (paused / expired / already-claimed) are skipped rather than
+    /// reverting the whole tx; errors only if every claim is skipped.
+    ClaimMany {
+        claims: Vec<ClaimMsg>,
+        allow_partial: Option<bool>,
+    },
+    /// After expiry the creator sweeps whatever was never claimed.
+    Clawback {
+        id: u64,
+    },
+    /// Recover tokens sent to the contract outside campaign accounting (wrong
+    /// address, wrong denom). Owner-only; capped at `balance − liabilities` so
+    /// it can never touch funds owed to claimants. Defaults: sweep all excess
+    /// to the owner.
+    Rescue {
+        denom: String,
+        amount: Option<Uint128>,
+        recipient: Option<String>,
+    },
+    /// Two-step ownership transfer (propose → accept).
+    TransferOwnership {
+        new_owner: String,
+    },
+    AcceptOwnership {},
+    /// Two-step per-campaign creator transfer (rotate a creator key).
+    TransferCreator {
+        id: u64,
+        new_creator: String,
+    },
+    AcceptCreator {
+        id: u64,
+    },
+    SetKeeper {
+        id: u64,
+        keeper: Option<String>,
+    },
+    /// Extend an expiry, or wind down a perpetual campaign with ≥7 days notice.
+    /// A frozen perpetual campaign's expiry is locked.
+    SetExpiry {
+        id: u64,
+        expiry: Timestamp,
+    },
+    SetCampaignPaused {
+        id: u64,
+        paused: bool,
+    },
+    UpdateMeta {
+        id: u64,
+        meta: Option<String>,
+        leaves_uri: Option<String>,
+    },
+    /// Owner config. Ownership is transferred via the two-step flow, not here.
+    UpdateConfig {
+        fee_bps: Option<u16>,
+        fee_collector: Option<String>,
+        paused: Option<bool>,
+    },
+}
+
+#[cw_serde]
+pub struct ClaimMsg {
+    pub id: u64,
+    pub amount: Uint128,
+    pub proof: Vec<HexBinary>,
+}
+
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    #[returns(crate::state::Config)]
+    Config {},
+    #[returns(CampaignResponse)]
+    Campaign { id: u64 },
+    #[returns(Vec<CampaignResponse>)]
+    Campaigns {
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(Vec<CampaignResponse>)]
+    CampaignsByCreator {
+        creator: String,
+        start_after: Option<u64>,
+        limit: Option<u32>,
+    },
+    #[returns(ClaimedResponse)]
+    Claimed { id: u64, address: String },
+    /// Paginated list of a campaign's claimants + their cumulative claimed
+    /// amounts. Powers the trippytools manage view without an off-chain indexer.
+    #[returns(ClaimsResponse)]
+    Claims {
+        id: u64,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Dry-run a claim: proof validity plus the payable amount right now
+    /// (zero when the campaign is paused, expired, swept, or exhausted).
+    #[returns(ClaimableResponse)]
+    Claimable {
+        id: u64,
+        address: String,
+        amount: Uint128,
+        proof: Vec<HexBinary>,
+    },
+    /// Exact funds to attach to move a campaign's declared total to `new_total`,
+    /// so integrators never have to replicate the fee rounding.
+    #[returns(FundingRequiredResponse)]
+    FundingRequired { id: u64, new_total: Uint128 },
+    /// Amount currently owed to claimants for a denom (Σ remaining across its
+    /// campaigns). Reconcile against the contract's bank balance.
+    #[returns(LiabilitiesResponse)]
+    Liabilities { denom: String },
+}
+
+#[cw_serde]
+pub struct CampaignResponse {
+    pub id: u64,
+    pub campaign: Campaign,
+    pub remaining: Uint128,
+}
+
+#[cw_serde]
+pub struct ClaimedResponse {
+    pub claimed: Uint128,
+}
+
+#[cw_serde]
+pub struct ClaimEntry {
+    pub address: Addr,
+    pub claimed: Uint128,
+}
+
+#[cw_serde]
+pub struct ClaimsResponse {
+    pub claims: Vec<ClaimEntry>,
+}
+
+#[cw_serde]
+pub struct ClaimableResponse {
+    pub valid: bool,
+    pub payable: Uint128,
+}
+
+#[cw_serde]
+pub struct FundingRequiredResponse {
+    pub delta: Uint128,
+    pub fee: Uint128,
+    pub required: Uint128,
+    pub denom: String,
+}
+
+#[cw_serde]
+pub struct LiabilitiesResponse {
+    pub owed: Uint128,
+}
+
+#[cw_serde]
+pub struct MigrateMsg {}

--- a/contracts/choice_claim_drops/src/state.rs
+++ b/contracts/choice_claim_drops/src/state.rs
@@ -1,0 +1,97 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, HexBinary, Timestamp, Uint128};
+use cw_storage_plus::{Item, Map};
+
+#[cw_serde]
+pub struct Config {
+    pub owner: Addr,
+    /// Two-step ownership transfer: a proposed owner who must `AcceptOwnership`
+    /// before the transfer takes effect, so a typo can never brick control.
+    pub pending_owner: Option<Addr>,
+    /// Platform fee in basis points, charged ON TOP of every funding delta and
+    /// forwarded to `fee_collector`. The campaign always retains exactly its
+    /// declared delta, so the fee never eats into claimants' allocations.
+    pub fee_bps: u16,
+    pub fee_collector: Addr,
+    /// Emergency stop: blocks create / update_root / claim / clawback.
+    pub paused: bool,
+}
+
+#[cw_serde]
+pub struct Campaign {
+    pub creator: Addr,
+    /// Two-step creator transfer target (rotate a lost/compromised creator key
+    /// without stranding the campaign's clawback + admin powers).
+    pub pending_creator: Option<Addr>,
+    /// Optional second address allowed to publish roots — the rewards keeper
+    /// bot for streaming campaigns. Only meaningful when `streaming`.
+    pub keeper: Option<Addr>,
+    /// Streaming campaigns accept repeated root updates and a keeper; ONLY the
+    /// contract owner may create them (the mutable root is a trusted-updater
+    /// surface — see README threat model). Non-streaming ("one-shot") campaigns
+    /// are auto-frozen on their first root publish, so a permissionless creator
+    /// can never republish over already-funded float. This split is the core of
+    /// the contract's safety model.
+    pub streaming: bool,
+    /// Native bank denom paid out by this campaign (tokenfactory / ibc / erc20:*).
+    pub denom: String,
+    /// Free-form JSON rendered by frontends (title, logo, description).
+    pub meta: String,
+    /// Where the full `(address, cumulative_amount)` leaves file for `root` is
+    /// published. Clients rebuild the tree from it and derive their own proofs;
+    /// it doubles as the public audit record of the campaign.
+    pub leaves_uri: String,
+    pub root: Option<HexBinary>,
+    /// Declared sum of all leaf amounts under `root`. The contract cannot see
+    /// the leaves, so honesty here is the publisher's responsibility; claims
+    /// are hard-capped at `total - claimed_total` regardless, which confines a
+    /// dishonest tree to its own campaign's balance.
+    pub total: Uint128,
+    /// The previous root stays claimable after an update so proofs fetched
+    /// just before a keeper publish don't race to failure. Safe under
+    /// cumulative semantics: an old leaf only ever claims less.
+    pub prev_root: Option<HexBinary>,
+    pub prev_total: Uint128,
+    pub claimed_total: Uint128,
+    /// Count of distinct addresses that have claimed at least once (manage-view
+    /// stat; avoids paginating every claimant just to count).
+    pub claimants: u64,
+    /// One-way switch blocking all future root updates. Auto-set on a one-shot
+    /// campaign's first publish; the owner may also set it on a streaming
+    /// campaign to end it. Also locks the expiry policy (a frozen perpetual
+    /// drop can never be given an expiry, so it can never be clawed back).
+    pub frozen: bool,
+    /// After expiry claims stop and the creator may claw back the remainder.
+    /// `None` = perpetual.
+    pub expiry: Option<Timestamp>,
+    pub paused: bool,
+    pub swept: bool,
+}
+
+impl Campaign {
+    pub fn remaining(&self) -> Uint128 {
+        if self.swept {
+            return Uint128::zero();
+        }
+        self.total
+            .checked_sub(self.claimed_total)
+            .unwrap_or_default()
+    }
+
+    pub fn is_expired(&self, now: Timestamp) -> bool {
+        matches!(self.expiry, Some(exp) if now >= exp)
+    }
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+pub const CAMPAIGN_SEQ: Item<u64> = Item::new("campaign_seq");
+pub const CAMPAIGNS: Map<u64, Campaign> = Map::new("campaigns");
+/// (campaign_id, claimant) -> lifetime cumulative amount already paid out.
+pub const CLAIMED: Map<(u64, &Addr), Uint128> = Map::new("claimed");
+/// (creator, campaign_id) index backing the CampaignsByCreator query.
+pub const CREATOR_CAMPAIGNS: Map<(&Addr, u64), ()> = Map::new("creator_campaigns");
+/// denom -> total currently owed to claimants (Σ remaining across that denom's
+/// campaigns). `Rescue` may only sweep the contract's bank balance above this,
+/// so accidentally mis-sent tokens are recoverable without ever touching funds
+/// promised to claimants.
+pub const LIABILITIES: Map<&str, Uint128> = Map::new("liabilities");

--- a/contracts/choice_claim_drops/src/testing.rs
+++ b/contracts/choice_claim_drops/src/testing.rs
@@ -1,0 +1,1033 @@
+use cosmwasm_std::testing::{
+    message_info, mock_dependencies, mock_dependencies_with_balance, mock_env, MockApi,
+    MockQuerier, MockStorage,
+};
+use cosmwasm_std::{
+    coins, from_json, Addr, BankMsg, Coin, CosmosMsg, Env, HexBinary, OwnedDeps, SubMsg, Timestamp,
+    Uint128,
+};
+
+use crate::contract::{execute, instantiate, migrate, query};
+use crate::error::ContractError;
+use crate::merkle;
+use crate::msg::{
+    CampaignResponse, ClaimEntry, ClaimMsg, ClaimableResponse, ClaimsResponse, ExecuteMsg,
+    FundingRequiredResponse, InitialRoot, InstantiateMsg, LiabilitiesResponse, MigrateMsg,
+    QueryMsg,
+};
+use crate::state::Config;
+
+type Deps = OwnedDeps<MockStorage, MockApi, MockQuerier>;
+
+const T0: u64 = 1_700_000_000;
+const DENOM: &str = "factory/inj1creator/SAI";
+
+// ---- test-side merkle builder (must mirror src/merkle.rs spec exactly) ----
+
+fn hash_pair(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    if a <= b {
+        h.update(a);
+        h.update(b);
+    } else {
+        h.update(b);
+        h.update(a);
+    }
+    h.finalize().into()
+}
+
+/// Returns (root, proof per entry). Odd nodes promote unchanged.
+fn build_tree(entries: &[(Addr, u128)]) -> (HexBinary, Vec<Vec<HexBinary>>) {
+    let leaves: Vec<[u8; 32]> = entries
+        .iter()
+        .map(|(a, amt)| merkle::leaf_hash(a.as_str(), Uint128::new(*amt)))
+        .collect();
+    let mut levels: Vec<Vec<[u8; 32]>> = vec![leaves];
+    while levels.last().unwrap().len() > 1 {
+        let prev = levels.last().unwrap();
+        let mut next = Vec::new();
+        for pair in prev.chunks(2) {
+            if pair.len() == 2 {
+                next.push(hash_pair(&pair[0], &pair[1]));
+            } else {
+                next.push(pair[0]);
+            }
+        }
+        levels.push(next);
+    }
+    let root = HexBinary::from(levels.last().unwrap()[0]);
+    let proofs = (0..entries.len())
+        .map(|leaf_idx| {
+            let mut proof = Vec::new();
+            let mut i = leaf_idx;
+            for level in &levels[..levels.len() - 1] {
+                let sib = i ^ 1;
+                if sib < level.len() {
+                    proof.push(HexBinary::from(level[sib]));
+                }
+                i /= 2;
+            }
+            proof
+        })
+        .collect();
+    (root, proofs)
+}
+
+// ---- fixtures ----
+
+fn init(deps: &mut Deps, fee_bps: u16, fee_collector: Option<String>) -> (Env, Addr) {
+    let mut env = mock_env();
+    env.block.time = Timestamp::from_seconds(T0);
+    let owner = deps.api.addr_make("owner");
+    instantiate(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        InstantiateMsg {
+            owner: None,
+            fee_bps,
+            fee_collector,
+        },
+    )
+    .unwrap();
+    (env, owner)
+}
+
+/// Create a one-shot (non-streaming) campaign, empty root.
+fn create_one_shot(deps: &mut Deps, env: &Env, creator: &Addr, expiry: Option<Timestamp>) -> u64 {
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(creator, &[]),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.to_string(),
+            meta: "{\"title\":\"drop\"}".to_string(),
+            keeper: None,
+            expiry,
+            streaming: false,
+            initial: None,
+        },
+    )
+    .unwrap();
+    from_json::<u64>(res.data.unwrap()).unwrap()
+}
+
+/// Create a streaming campaign as `owner` with an optional keeper.
+fn create_streaming(
+    deps: &mut Deps,
+    env: &Env,
+    owner: &Addr,
+    keeper: Option<String>,
+    expiry: Option<Timestamp>,
+) -> u64 {
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(owner, &[]),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.to_string(),
+            meta: String::new(),
+            keeper,
+            expiry,
+            streaming: true,
+            initial: None,
+        },
+    )
+    .unwrap();
+    from_json::<u64>(res.data.unwrap()).unwrap()
+}
+
+fn update_root(
+    deps: &mut Deps,
+    env: &Env,
+    sender: &Addr,
+    id: u64,
+    root: &HexBinary,
+    total: u128,
+    attach: u128,
+) -> Result<cosmwasm_std::Response, ContractError> {
+    let funds = if attach == 0 {
+        vec![]
+    } else {
+        coins(attach, DENOM)
+    };
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(sender, &funds),
+        ExecuteMsg::UpdateRoot {
+            id,
+            root: root.clone(),
+            total: Uint128::new(total),
+            leaves_uri: "https://tools.trippyinj.xyz/leaves/1.json".to_string(),
+        },
+    )
+}
+
+fn claim(
+    deps: &mut Deps,
+    env: &Env,
+    sender: &Addr,
+    id: u64,
+    amount: u128,
+    proof: &[HexBinary],
+) -> Result<cosmwasm_std::Response, ContractError> {
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(sender, &[]),
+        ExecuteMsg::Claim {
+            id,
+            amount: Uint128::new(amount),
+            proof: proof.to_vec(),
+        },
+    )
+}
+
+fn query_campaign(deps: &Deps, env: &Env, id: u64) -> CampaignResponse {
+    from_json(query(deps.as_ref(), env.clone(), QueryMsg::Campaign { id }).unwrap()).unwrap()
+}
+
+fn liabilities(deps: &Deps, env: &Env, denom: &str) -> Uint128 {
+    let r: LiabilitiesResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::Liabilities {
+                denom: denom.to_string(),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    r.owed
+}
+
+fn assert_bank_send(msg: &SubMsg, to: &Addr, amount: u128, denom: &str) {
+    match &msg.msg {
+        CosmosMsg::Bank(BankMsg::Send {
+            to_address,
+            amount: sent,
+        }) => {
+            assert_eq!(to_address, to.as_str());
+            assert_eq!(sent, &coins(amount, denom));
+        }
+        other => panic!("expected BankMsg::Send, got {other:?}"),
+    }
+}
+
+// ---- tests ----
+
+#[test]
+fn instantiate_caps_fee_bps() {
+    let mut deps = mock_dependencies();
+    let owner = deps.api.addr_make("owner");
+    let err = instantiate(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&owner, &[]),
+        InstantiateMsg {
+            owner: None,
+            fee_bps: 1_001,
+            fee_collector: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::FeeTooHigh { max: 1_000 });
+}
+
+#[test]
+fn permission_split_streaming_is_owner_only() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 0, None);
+    let rando = deps.api.addr_make("rando");
+
+    // non-owner cannot create a streaming campaign
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&rando, &[]),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.into(),
+            meta: String::new(),
+            keeper: None,
+            expiry: None,
+            streaming: true,
+            initial: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::StreamingRequiresOwner);
+
+    // non-owner cannot attach a keeper (implies streaming)
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&rando, &[]),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.into(),
+            meta: String::new(),
+            keeper: Some(rando.to_string()),
+            expiry: None,
+            streaming: false,
+            initial: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::KeeperRequiresStreaming);
+}
+
+#[test]
+fn one_shot_auto_freezes_on_first_publish() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 0, None);
+    let creator = deps.api.addr_make("creator");
+    let alice = deps.api.addr_make("alice");
+    let id = create_one_shot(&mut deps, &env, &creator, None);
+    let (root, proofs) = build_tree(&[(alice.clone(), 100)]);
+
+    update_root(&mut deps, &env, &creator, id, &root, 100, 100).unwrap();
+    // frozen automatically: a second publish is rejected
+    assert!(query_campaign(&deps, &env, id).campaign.frozen);
+    let err = update_root(&mut deps, &env, &creator, id, &root, 200, 100).unwrap_err();
+    assert_eq!(err, ContractError::Frozen);
+    // but it stays claimable
+    claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap();
+}
+
+#[test]
+fn atomic_create_fund_and_freeze_one_shot() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 0, None);
+    let creator = deps.api.addr_make("creator");
+    let alice = deps.api.addr_make("alice");
+    let bob = deps.api.addr_make("bob");
+    let (root, proofs) = build_tree(&[(alice.clone(), 700), (bob.clone(), 300)]);
+
+    // wrong attached amount is rejected atomically
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &coins(999, DENOM)),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.into(),
+            meta: String::new(),
+            keeper: None,
+            expiry: None,
+            streaming: false,
+            initial: Some(InitialRoot {
+                root: root.clone(),
+                total: Uint128::new(1_000),
+                leaves_uri: String::new(),
+            }),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::InvalidFunds { .. }));
+
+    // correct: create + fund + publish + auto-freeze in one tx
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &coins(1_000, DENOM)),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.into(),
+            meta: String::new(),
+            keeper: None,
+            expiry: None,
+            streaming: false,
+            initial: Some(InitialRoot {
+                root: root.clone(),
+                total: Uint128::new(1_000),
+                leaves_uri: String::new(),
+            }),
+        },
+    )
+    .unwrap();
+    let id: u64 = from_json(res.data.unwrap()).unwrap();
+    let c = query_campaign(&deps, &env, id);
+    assert!(c.campaign.frozen);
+    assert_eq!(c.remaining, Uint128::new(1_000));
+    assert_eq!(liabilities(&deps, &env, DENOM), Uint128::new(1_000));
+
+    claim(&mut deps, &env, &alice, id, 700, &proofs[0]).unwrap();
+    claim(&mut deps, &env, &bob, id, 300, &proofs[1]).unwrap();
+    assert_eq!(query_campaign(&deps, &env, id).remaining, Uint128::zero());
+    assert_eq!(liabilities(&deps, &env, DENOM), Uint128::zero());
+}
+
+#[test]
+fn streaming_allows_repeated_updates_and_keeper() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let keeper = deps.api.addr_make("keeper");
+    let alice = deps.api.addr_make("alice");
+    let id = create_streaming(&mut deps, &env, &owner, Some(keeper.to_string()), None);
+
+    let (root1, proofs1) = build_tree(&[(alice.clone(), 100)]);
+    update_root(&mut deps, &env, &keeper, id, &root1, 100, 100).unwrap();
+    assert!(!query_campaign(&deps, &env, id).campaign.frozen);
+    claim(&mut deps, &env, &alice, id, 100, &proofs1[0]).unwrap();
+
+    // next epoch: keeper raises the lifetime total, attaches the delta only
+    let (root2, proofs2) = build_tree(&[(alice.clone(), 250)]);
+    update_root(&mut deps, &env, &keeper, id, &root2, 250, 150).unwrap();
+    let res = claim(&mut deps, &env, &alice, id, 250, &proofs2[0]).unwrap();
+    assert_bank_send(&res.messages[0], &alice, 150, DENOM);
+}
+
+#[test]
+fn keeper_zero_delta_republish_still_bounded_but_note_streaming_trust() {
+    // Documents the streaming trust model: a keeper CAN reassign unclaimed float
+    // on a streaming campaign (owner-only to create). This is why streaming is
+    // owner-gated; one-shots (auto-frozen) are immune to the same move.
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let keeper = deps.api.addr_make("keeper");
+    let alice = deps.api.addr_make("alice");
+    let id = create_streaming(&mut deps, &env, &owner, Some(keeper.to_string()), None);
+    let (root, _) = build_tree(&[(alice.clone(), 1_000)]);
+    update_root(&mut deps, &env, &keeper, id, &root, 1_000, 1_000).unwrap();
+
+    // one-shot equivalent would be frozen; confirm the frozen guard is the wall
+    let creator = deps.api.addr_make("creator");
+    let one = create_one_shot(&mut deps, &env, &creator, None);
+    let (r2, _) = build_tree(&[(alice.clone(), 500)]);
+    update_root(&mut deps, &env, &creator, one, &r2, 500, 500).unwrap();
+    let (evil, _) = build_tree(&[(creator.clone(), 500)]);
+    let err = update_root(&mut deps, &env, &creator, one, &evil, 500, 0).unwrap_err();
+    assert_eq!(err, ContractError::Frozen);
+}
+
+#[test]
+fn update_root_enforces_exact_funding() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root, _) = build_tree(&[(alice, 100)]);
+
+    for attach in [99u128, 101] {
+        let err = update_root(&mut deps, &env, &owner, id, &root, 100, attach).unwrap_err();
+        assert!(matches!(err, ContractError::InvalidFunds { .. }));
+    }
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &coins(100, "inj")),
+        ExecuteMsg::UpdateRoot {
+            id,
+            root: root.clone(),
+            total: Uint128::new(100),
+            leaves_uri: String::new(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::InvalidFunds { .. }));
+
+    update_root(&mut deps, &env, &owner, id, &root, 100, 100).unwrap();
+    assert_eq!(query_campaign(&deps, &env, id).remaining, Uint128::new(100));
+
+    // zero-delta republish (corrected tree, same total): no funds allowed
+    update_root(&mut deps, &env, &owner, id, &root, 100, 0).unwrap();
+    let err = update_root(&mut deps, &env, &owner, id, &root, 100, 1).unwrap_err();
+    assert_eq!(err, ContractError::UnexpectedFunds);
+}
+
+#[test]
+fn fee_is_ceiled_and_charged_on_top() {
+    let mut deps = mock_dependencies();
+    let collector = deps.api.addr_make("collector");
+    let (env, _owner) = init(&mut deps, 100, Some(collector.to_string())); // 1%
+    let owner = deps.api.addr_make("owner");
+    let alice = deps.api.addr_make("alice");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+
+    // delta 101 at 1% -> ceil(1.01) = 2, so attach 103; collector gets 2
+    let (root, proofs) = build_tree(&[(alice.clone(), 101)]);
+    let err = update_root(&mut deps, &env, &owner, id, &root, 101, 102).unwrap_err();
+    assert!(matches!(err, ContractError::InvalidFunds { .. }));
+    let res = update_root(&mut deps, &env, &owner, id, &root, 101, 103).unwrap();
+    assert_eq!(res.messages.len(), 1);
+    assert_bank_send(&res.messages[0], &collector, 2, DENOM);
+
+    // campaign keeps exactly the declared total for claimants
+    assert_eq!(liabilities(&deps, &env, DENOM), Uint128::new(101));
+    let res = claim(&mut deps, &env, &alice, id, 101, &proofs[0]).unwrap();
+    assert_bank_send(&res.messages[0], &alice, 101, DENOM);
+}
+
+#[test]
+fn funding_required_query_matches_exact_funds() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 100, None);
+    let owner = deps.api.addr_make("owner");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+    let alice = deps.api.addr_make("alice");
+    let (root, _) = build_tree(&[(alice, 101)]);
+
+    let r: FundingRequiredResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::FundingRequired {
+                id,
+                new_total: Uint128::new(101),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(r.delta, Uint128::new(101));
+    assert_eq!(r.fee, Uint128::new(2));
+    assert_eq!(r.required, Uint128::new(103));
+    assert_eq!(r.denom, DENOM);
+    // attaching exactly `required` succeeds
+    update_root(&mut deps, &env, &owner, id, &root, 101, r.required.u128()).unwrap();
+}
+
+#[test]
+fn claim_pays_once_and_caps_overallocation_per_campaign() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let bob = deps.api.addr_make("bob");
+    let carol = deps.api.addr_make("carol");
+
+    // dishonest tree: leaves sum 200, only 100 declared/attached
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root, proofs) = build_tree(&[(alice.clone(), 100), (bob.clone(), 100)]);
+    update_root(&mut deps, &env, &owner, id, &root, 100, 100).unwrap();
+
+    // isolated honest campaign
+    let id2 = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root2, proofs2) = build_tree(&[(carol.clone(), 500)]);
+    update_root(&mut deps, &env, &owner, id2, &root2, 500, 500).unwrap();
+
+    claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap();
+    let err = claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap_err();
+    assert_eq!(err, ContractError::NothingToClaim);
+    let err = claim(&mut deps, &env, &bob, id, 100, &proofs[1]).unwrap_err();
+    assert_eq!(err, ContractError::ExceedsCampaignFunds);
+
+    assert_eq!(
+        query_campaign(&deps, &env, id2).remaining,
+        Uint128::new(500)
+    );
+    let res = claim(&mut deps, &env, &carol, id2, 500, &proofs2[0]).unwrap();
+    assert_bank_send(&res.messages[0], &carol, 500, DENOM);
+}
+
+#[test]
+fn previous_root_stays_claimable_after_update() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let bob = deps.api.addr_make("bob");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+
+    let (root1, proofs1) = build_tree(&[(alice.clone(), 100), (bob.clone(), 50)]);
+    update_root(&mut deps, &env, &owner, id, &root1, 150, 150).unwrap();
+    let (root2, proofs2) = build_tree(&[(alice.clone(), 250), (bob.clone(), 50)]);
+    update_root(&mut deps, &env, &owner, id, &root2, 300, 150).unwrap();
+
+    // bob's pre-update proof still verifies via prev_root
+    let res = claim(&mut deps, &env, &bob, id, 50, &proofs1[1]).unwrap();
+    assert_bank_send(&res.messages[0], &bob, 50, DENOM);
+    let err = claim(&mut deps, &env, &bob, id, 50, &proofs2[1]).unwrap_err();
+    assert_eq!(err, ContractError::NothingToClaim);
+}
+
+#[test]
+fn invalid_proofs_are_rejected() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let bob = deps.api.addr_make("bob");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root, proofs) = build_tree(&[(alice.clone(), 100), (bob.clone(), 50)]);
+    update_root(&mut deps, &env, &owner, id, &root, 150, 150).unwrap();
+
+    let err = claim(&mut deps, &env, &alice, id, 101, &proofs[0]).unwrap_err();
+    assert_eq!(err, ContractError::InvalidProof);
+    let err = claim(&mut deps, &env, &alice, id, 50, &proofs[1]).unwrap_err();
+    assert_eq!(err, ContractError::InvalidProof);
+}
+
+#[test]
+fn freeze_locks_expiry_of_a_perpetual_drop() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 0, None);
+    let creator = deps.api.addr_make("creator");
+    let alice = deps.api.addr_make("alice");
+    // perpetual one-shot: create+publish auto-freezes, expiry stays None
+    let id = create_one_shot(&mut deps, &env, &creator, None);
+    let (root, _) = build_tree(&[(alice.clone(), 100)]);
+    update_root(&mut deps, &env, &creator, id, &root, 100, 100).unwrap();
+    assert!(query_campaign(&deps, &env, id).campaign.frozen);
+
+    // cannot introduce an expiry (and therefore cannot ever claw back)
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::SetExpiry {
+            id,
+            expiry: Timestamp::from_seconds(T0 + 30 * 24 * 3_600),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::FrozenExpiryLocked);
+}
+
+#[test]
+fn expiry_blocks_claims_and_enables_clawback() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 0, None);
+    let creator = deps.api.addr_make("creator");
+    let alice = deps.api.addr_make("alice");
+    let bob = deps.api.addr_make("bob");
+    let expiry = Timestamp::from_seconds(T0 + 1_000);
+    let id = create_one_shot(&mut deps, &env, &creator, Some(expiry));
+    let (root, proofs) = build_tree(&[(alice.clone(), 100), (bob.clone(), 50)]);
+    update_root(&mut deps, &env, &creator, id, &root, 150, 150).unwrap();
+
+    claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap();
+    assert_eq!(liabilities(&deps, &env, DENOM), Uint128::new(50));
+
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::Clawback { id },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::NotExpired);
+
+    let mut late = env.clone();
+    late.block.time = expiry;
+    let err = claim(&mut deps, &late, &bob, id, 50, &proofs[1]).unwrap_err();
+    assert_eq!(err, ContractError::Expired);
+
+    // bob's unclaimed 50 is swept to the creator, and liabilities clear
+    let res = execute(
+        deps.as_mut(),
+        late.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::Clawback { id },
+    )
+    .unwrap();
+    assert_bank_send(&res.messages[0], &creator, 50, DENOM);
+    assert_eq!(liabilities(&deps, &late, DENOM), Uint128::zero());
+    // swept campaign reports zero remaining
+    assert_eq!(query_campaign(&deps, &late, id).remaining, Uint128::zero());
+
+    let err = execute(
+        deps.as_mut(),
+        late.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::Clawback { id },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::Swept);
+}
+
+#[test]
+fn two_step_ownership_transfer() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let new_owner = deps.api.addr_make("new_owner");
+    let rando = deps.api.addr_make("rando");
+
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::TransferOwnership {
+            new_owner: new_owner.to_string(),
+        },
+    )
+    .unwrap();
+
+    // old owner still in charge until accepted
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&rando, &[]),
+        ExecuteMsg::AcceptOwnership {},
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::NoPendingOwnership);
+
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&new_owner, &[]),
+        ExecuteMsg::AcceptOwnership {},
+    )
+    .unwrap();
+
+    let cfg: Config =
+        from_json(query(deps.as_ref(), env.clone(), QueryMsg::Config {}).unwrap()).unwrap();
+    assert_eq!(cfg.owner, new_owner);
+    assert_eq!(cfg.pending_owner, None);
+
+    // old owner can no longer create streaming campaigns; new owner can
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.into(),
+            meta: String::new(),
+            keeper: None,
+            expiry: None,
+            streaming: true,
+            initial: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::StreamingRequiresOwner);
+    create_streaming(&mut deps, &env, &new_owner, None, None);
+}
+
+#[test]
+fn two_step_creator_transfer_moves_index() {
+    let mut deps = mock_dependencies();
+    let (env, _owner) = init(&mut deps, 0, None);
+    let creator = deps.api.addr_make("creator");
+    let new_creator = deps.api.addr_make("new_creator");
+    let id = create_one_shot(&mut deps, &env, &creator, None);
+
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::TransferCreator {
+            id,
+            new_creator: new_creator.to_string(),
+        },
+    )
+    .unwrap();
+    // wrong acceptor
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::AcceptCreator { id },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::NoPendingCreator);
+
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&new_creator, &[]),
+        ExecuteMsg::AcceptCreator { id },
+    )
+    .unwrap();
+
+    // creator power moved: old creator can't freeze, new one can administer
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::SetCampaignPaused { id, paused: true },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized);
+
+    // index moved to new creator
+    let by_new: Vec<CampaignResponse> = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::CampaignsByCreator {
+                creator: new_creator.to_string(),
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(by_new.len(), 1);
+    let by_old: Vec<CampaignResponse> = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::CampaignsByCreator {
+                creator: creator.to_string(),
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(by_old.is_empty());
+}
+
+#[test]
+fn claim_many_atomic_and_partial() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let id1 = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root1, proofs1) = build_tree(&[(alice.clone(), 100)]);
+    update_root(&mut deps, &env, &owner, id1, &root1, 100, 100).unwrap();
+    let id2 = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root2, proofs2) = build_tree(&[(alice.clone(), 40)]);
+    update_root(&mut deps, &env, &owner, id2, &root2, 40, 40).unwrap();
+
+    // pause id2 so a naive claim-all would fail
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::SetCampaignPaused {
+            id: id2,
+            paused: true,
+        },
+    )
+    .unwrap();
+
+    let alice_id1 = ClaimMsg {
+        id: id1,
+        amount: Uint128::new(100),
+        proof: proofs1[0].clone(),
+    };
+    let alice_id2 = ClaimMsg {
+        id: id2,
+        amount: Uint128::new(40),
+        proof: proofs2[0].clone(),
+    };
+
+    // atomic: the whole thing reverts on the paused campaign. Paused campaign is
+    // listed first so the error fires before any state is written (unit-test
+    // execute() does not roll back storage on Err the way the chain does).
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&alice, &[]),
+        ExecuteMsg::ClaimMany {
+            claims: vec![alice_id2.clone(), alice_id1.clone()],
+            allow_partial: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::CampaignPaused);
+
+    // partial: id1 pays, id2 is skipped
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&alice, &[]),
+        ExecuteMsg::ClaimMany {
+            claims: vec![alice_id1, alice_id2],
+            allow_partial: Some(true),
+        },
+    )
+    .unwrap();
+    assert_eq!(res.messages.len(), 1);
+    assert_bank_send(&res.messages[0], &alice, 100, DENOM);
+}
+
+#[test]
+fn rescue_only_sweeps_unencumbered_balance() {
+    // Seed the contract with 1_100 of DENOM; a campaign will owe 1_000.
+    let mut deps = mock_dependencies_with_balance(&[Coin::new(1_100u128, DENOM)]);
+    let (env, owner) = init(&mut deps, 0, None);
+    let creator = deps.api.addr_make("creator");
+    let alice = deps.api.addr_make("alice");
+    let (root, _) = build_tree(&[(alice.clone(), 1_000)]);
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &coins(1_000, DENOM)),
+        ExecuteMsg::CreateCampaign {
+            denom: DENOM.into(),
+            meta: String::new(),
+            keeper: None,
+            expiry: None,
+            streaming: false,
+            initial: Some(InitialRoot {
+                root,
+                total: Uint128::new(1_000),
+                leaves_uri: String::new(),
+            }),
+        },
+    )
+    .unwrap();
+
+    // non-owner cannot rescue
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&creator, &[]),
+        ExecuteMsg::Rescue {
+            denom: DENOM.into(),
+            amount: None,
+            recipient: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, ContractError::Unauthorized);
+
+    // asking for more than the 100 excess is rejected
+    let err = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::Rescue {
+            denom: DENOM.into(),
+            amount: Some(Uint128::new(101)),
+            recipient: None,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::RescueExceedsExcess {
+            available: Uint128::new(100)
+        }
+    );
+
+    // sweeping the excess (100) to owner succeeds; claimant funds untouched
+    let res = execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::Rescue {
+            denom: DENOM.into(),
+            amount: None,
+            recipient: None,
+        },
+    )
+    .unwrap();
+    assert_bank_send(&res.messages[0], &owner, 100, DENOM);
+}
+
+#[test]
+fn pause_paths() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root, proofs) = build_tree(&[(alice.clone(), 100)]);
+    update_root(&mut deps, &env, &owner, id, &root, 100, 100).unwrap();
+
+    // global pause blocks funds-moving messages
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::UpdateConfig {
+            fee_bps: None,
+            fee_collector: None,
+            paused: Some(true),
+        },
+    )
+    .unwrap();
+    let err = claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap_err();
+    assert_eq!(err, ContractError::Paused);
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::UpdateConfig {
+            fee_bps: None,
+            fee_collector: None,
+            paused: Some(false),
+        },
+    )
+    .unwrap();
+
+    // campaign pause blocks claims but not administration
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::SetCampaignPaused { id, paused: true },
+    )
+    .unwrap();
+    let err = claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap_err();
+    assert_eq!(err, ContractError::CampaignPaused);
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&owner, &[]),
+        ExecuteMsg::SetCampaignPaused { id, paused: false },
+    )
+    .unwrap();
+    claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap();
+}
+
+#[test]
+fn claims_and_claimable_queries() {
+    let mut deps = mock_dependencies();
+    let (env, owner) = init(&mut deps, 0, None);
+    let alice = deps.api.addr_make("alice");
+    let bob = deps.api.addr_make("bob");
+    let id = create_streaming(&mut deps, &env, &owner, None, None);
+    let (root, proofs) = build_tree(&[(alice.clone(), 100), (bob.clone(), 50)]);
+    update_root(&mut deps, &env, &owner, id, &root, 150, 150).unwrap();
+
+    // Claimable dry-run
+    let r: ClaimableResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::Claimable {
+                id,
+                address: alice.to_string(),
+                amount: Uint128::new(100),
+                proof: proofs[0].clone(),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(r.valid);
+    assert_eq!(r.payable, Uint128::new(100));
+
+    claim(&mut deps, &env, &alice, id, 100, &proofs[0]).unwrap();
+    claim(&mut deps, &env, &bob, id, 50, &proofs[1]).unwrap();
+
+    // claimants counter + paginated Claims list
+    assert_eq!(query_campaign(&deps, &env, id).campaign.claimants, 2);
+    let page: ClaimsResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::Claims {
+                id,
+                start_after: None,
+                limit: Some(10),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(page.claims.len(), 2);
+    let total: u128 = page
+        .claims
+        .iter()
+        .map(|c: &ClaimEntry| c.claimed.u128())
+        .sum();
+    assert_eq!(total, 150);
+}
+
+#[test]
+fn migrate_rejects_downgrade() {
+    let mut deps = mock_dependencies();
+    let (_env, _owner) = init(&mut deps, 0, None);
+    // pretend a newer version is stored, then migrate with the (older) crate version
+    cw2::set_contract_version(&mut deps.storage, "crates.io:choice-claim-drops", "9.9.9").unwrap();
+    let err = migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap_err();
+    match err {
+        ContractError::Std(e) => assert!(e.to_string().contains("cannot migrate down")),
+        other => panic!("expected downgrade rejection, got {other:?}"),
+    }
+}

--- a/deploy/instantiate_claim_drops.sh
+++ b/deploy/instantiate_claim_drops.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euo pipefail
+
+# Instantiate a choice_claim_drops hub.
+#
+# Required env var (or positional arg 1):
+#   CLAIM_DROPS_CODE_ID   code id from ./deploy/upload_claim_drops_code.sh
+#
+# Optional env vars (with defaults):
+#   NETWORK         testnet | mainnet (default: testnet)
+#   OWNER           per-instance owner: may create streaming campaigns, run
+#                   UpdateConfig / Rescue, and freeze a stream. One-shot drops
+#                   are permissionless regardless. Default: $SIGNER_ADDRESS.
+#   FEE_BPS         platform fee in bps charged ON TOP of each funding delta,
+#                   paid to FEE_COLLECTOR. Contract caps it at 1000 (10%).
+#                   Default: 0 — the trippytools tool charges its own SHROOM
+#                   fee off-chain, so the on-chain fee stays off.
+#   FEE_COLLECTOR   recipient of the platform fee. Default: $OWNER.
+#   LABEL           wasm contract label (default: "Choice Claim Drops v1.1.0")
+#   ADMIN           wasm admin for this instance. Default: $SIGNER_ADDRESS.
+#
+# Usage:
+#   NETWORK=testnet CLAIM_DROPS_CODE_ID=1234 ./deploy/instantiate_claim_drops.sh
+#   ./deploy/instantiate_claim_drops.sh 1234           # positional, testnet
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CLAIM_DROPS_CODE_ID="${CLAIM_DROPS_CODE_ID:-${1:-}}"
+OWNER="${OWNER:-$SIGNER_ADDRESS}"
+FEE_BPS="${FEE_BPS:-0}"
+FEE_COLLECTOR="${FEE_COLLECTOR:-$OWNER}"
+LABEL="${LABEL:-Choice Claim Drops v1.1.0}"
+ADMIN="${ADMIN:-$SIGNER_ADDRESS}"
+
+if [ -z "$CLAIM_DROPS_CODE_ID" ]; then
+    echo "ERROR: CLAIM_DROPS_CODE_ID is required."
+    echo "       Pass via env var or positional arg 1."
+    echo "       Run ./deploy/upload_claim_drops_code.sh first to get it."
+    exit 1
+fi
+if ! [[ "$CLAIM_DROPS_CODE_ID" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: CLAIM_DROPS_CODE_ID '$CLAIM_DROPS_CODE_ID' is not an integer."; exit 1
+fi
+if ! [[ "$FEE_BPS" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: FEE_BPS '$FEE_BPS' is not an integer."; exit 1
+fi
+if [ "$FEE_BPS" -gt 1000 ]; then
+    echo "ERROR: FEE_BPS=$FEE_BPS exceeds the contract's 1000 bps (10%) cap."
+    exit 1
+fi
+
+banner "🎁 INSTANTIATE CHOICE CLAIM DROPS"
+echo "  Code id:       $CLAIM_DROPS_CODE_ID"
+echo "  Owner:         $OWNER"
+echo "  Fee bps:       $FEE_BPS"
+echo "  Fee collector: $FEE_COLLECTOR"
+echo "  Wasm admin:    $ADMIN"
+echo " "
+
+# fee_bps is u16 → JSON number, not string.
+INIT_MSG=$(cat <<EOF
+{
+  "owner": "$OWNER",
+  "fee_bps": $FEE_BPS,
+  "fee_collector": "$FEE_COLLECTOR"
+}
+EOF
+)
+
+echo "-------------------------------------------------"
+echo "  InstantiateMsg:"
+echo "-------------------------------------------------"
+echo "$INIT_MSG"
+echo " "
+
+echo "-------------------------------------------------"
+echo "  Broadcasting instantiate..."
+echo "-------------------------------------------------"
+CLAIM_DROPS_ADDR=$(instantiate_contract "$CLAIM_DROPS_CODE_ID" "$INIT_MSG" "$LABEL" "$ADMIN")
+
+echo " "
+echo "-------------------------------------------------"
+echo "  Config query"
+echo "-------------------------------------------------"
+injectived query wasm contract-state smart "$CLAIM_DROPS_ADDR" '{"config":{}}' \
+    --node="$NODE" --output json | python3 -m json.tool
+echo " "
+
+echo "================================================="
+echo "  ✅ CLAIM DROPS INSTANTIATED"
+echo "================================================="
+echo "  Address:       $CLAIM_DROPS_ADDR"
+echo "  Owner:         $OWNER"
+echo "  Fee bps:       $FEE_BPS"
+echo "  Fee collector: $FEE_COLLECTOR"
+echo " "
+
+# Machine-readable marker.
+echo "DEPLOY_CAPTURE_CLAIM_DROPS_ADDR=$CLAIM_DROPS_ADDR"
+echo " "
+
+echo "  Next: set CLAIM_DROPS_CONTRACT.$NETWORK in trippytools"
+echo "  (src/utils/claimDrops/config.ts) to $CLAIM_DROPS_ADDR"
+echo " "

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -74,6 +74,13 @@ wait_for_tx() {
 }
 
 # Store a wasm. Echoes the resulting code id to stdout on success.
+#
+# Set STORE_EXTRA_ARGS to append flags to `tx wasm store` — chiefly the code's
+# instantiate permission, which otherwise falls through to the chain's
+# `instantiate_default_permission` param. A contract meant to be instantiated by
+# third parties (see choice_claim_drops' own-instance model) must pass
+# `--instantiate-everybody=true` explicitly rather than inherit a chain default
+# that governance can change. Word-split on purpose so callers can pass several.
 store_contract() {
     local wasm_path="$1"
     if [ ! -f "$wasm_path" ]; then
@@ -81,10 +88,12 @@ store_contract() {
         return 1
     fi
     local tx_output txhash query_output code_id
+    # shellcheck disable=SC2086
     tx_output=$(printf '%s\n' "$STORE_PASSWORD" | injectived tx wasm store "$wasm_path" \
         --from="$STORE_FROM" \
         --chain-id="$CHAIN_ID" \
         --yes --fees="$FEES" --gas="$GAS" \
+        ${STORE_EXTRA_ARGS:-} \
         --node="$NODE" 2>&1)
     txhash=$(echo "$tx_output" | grep -o 'txhash: [A-F0-9]*' | awk '{print $2}')
     if [ -z "$txhash" ]; then

--- a/deploy/network/mainnet.env
+++ b/deploy/network/mainnet.env
@@ -4,7 +4,9 @@
 NODE="https://sentry.tm.injective.network:443"
 CHAIN_ID="injective-1"
 
-GAS="3500000"
+# 600KB optimized wasm stores simulate to ~3.9M gas; 6M gives headroom.
+# FEES (0.0015 INJ) covers up to ~9.375M gas at the 0.16 gwei min price.
+GAS="6000000"
 FEES="1500000000000000inj"
 
 # Keystore key. Must already exist in `injectived keys list`.

--- a/deploy/upload_claim_drops_code.sh
+++ b/deploy/upload_claim_drops_code.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Upload choice_claim_drops.wasm with InstantiatePermission: Everybody.
+#
+# The permission is the point, not a detail. choice_claim_drops uses an
+# own-instance deployment model: `owner` is per-instance and all state
+# (campaigns, liabilities, fee config) is isolated per instance, so anyone who
+# wants owner-only streaming campaigns deploys their OWN instance from this
+# code id rather than being added to an allowlist on ours. That only works if
+# the code is instantiable permissionlessly — hence --instantiate-everybody.
+#
+# Uploading the code still needs whatever permission the chain grants for
+# MsgStoreCode (on Injective mainnet: Choice's upload permission). Instantiate
+# is a separate check, which is what we're opening here.
+#
+# Usage:
+#   NETWORK=testnet ./deploy/upload_claim_drops_code.sh   # default
+#   NETWORK=mainnet ./deploy/upload_claim_drops_code.sh
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+banner "🚀 UPLOAD CLAIM DROPS CODE"
+
+ARTIFACTS_DIR="$(cd "$DEPLOY_DIR/.." && pwd)/artifacts"
+WASM="$ARTIFACTS_DIR/choice_claim_drops.wasm"
+
+echo "-------------------------------------------------"
+echo "  Storing choice_claim_drops.wasm"
+echo "  Instantiate permission: Everybody"
+echo "-------------------------------------------------"
+
+STORE_EXTRA_ARGS="--instantiate-everybody=true"
+export STORE_EXTRA_ARGS
+
+CLAIM_DROPS_CODE_ID=$(store_contract "$WASM")
+echo "  ✅ choice_claim_drops code id: $CLAIM_DROPS_CODE_ID"
+echo " "
+
+echo "-------------------------------------------------"
+echo "  Verifying instantiate permission on chain"
+echo "-------------------------------------------------"
+injectived query wasm code-info "$CLAIM_DROPS_CODE_ID" --node="$NODE" --output json \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print("  data_hash:  ", d.get("data_hash")); print("  creator:    ", d.get("creator")); print("  permission: ", json.dumps(d.get("instantiate_permission")))'
+echo " "
+
+echo "================================================="
+echo "  ✅ UPLOAD COMPLETE"
+echo "================================================="
+echo "  choice_claim_drops  code id: $CLAIM_DROPS_CODE_ID"
+echo " "
+
+# Machine-readable marker for Makefile / script capture.
+echo "DEPLOY_CAPTURE_CLAIM_DROPS_CODE_ID=$CLAIM_DROPS_CODE_ID"
+echo " "
+
+echo "  Next:"
+echo "      NETWORK=$NETWORK \\"
+echo "      CLAIM_DROPS_CODE_ID=$CLAIM_DROPS_CODE_ID \\"
+echo "      ./deploy/instantiate_claim_drops.sh"
+echo " "


### PR DESCRIPTION
New `contracts/choice_claim_drops` — one deployed instance hosts many independent claim campaigns. Serves two use cases as the same cumulative-merkle object: permissionless one-shot airdrops (community drops and high-value single drops) and owner-only keeper-driven reward streams (the SAI trading-rewards program).

## Safety model — the permission split
- **One-shot (`streaming: false`)** — permissionless. **Auto-frozen on its first published root**, so already-funded float can never be reassigned by a later republish. Supports atomic **create + fund + publish + freeze in one tx** (`CreateCampaign { initial }`), so a high-value drop's claim link is never shareable before the root is immutable.
- **Streaming (`streaming: true`)** — **owner-only**; accepts repeated `UpdateRoot`s and a keeper bot for daily reward epochs (a trusted-updater surface — keep the keeper key hot-but-poor). Every instance is fully isolated (own `owner`/campaigns/liabilities/fee config), so **third parties who want streaming deploy their own instance** — no allowlist. `owner` defaults to the instantiator.

## Invariants & recovery
- **Exact-funding solvency**: publishing a root attaches exactly `total − prev_total` (plus a ceil-rounded platform fee on top); payouts are hard-capped at `total − claimed_total`, confining a dishonest tree to its own campaign.
- **Per-denom liabilities ledger** + owner `Rescue` capped at `balance − liabilities`: mis-sent tokens are recoverable, claimant funds never are.
- **Dual-root claim window** (prev root stays claimable, kills the proof-fetch race); **freeze also locks a perpetual campaign's expiry** (an immutable drop can't be clawed back); extend-only expiry with a 7-day wind-down notice; **two-step ownership + per-campaign creator transfers**; `migrate` rejects downgrades.

## Notes for review
- Origin: brainstormed from a security audit (a HIGH — keeper/creator draining unclaimed float via a zero-delta self-allocating root republish — is closed structurally by the permission split; the payout cap and per-campaign isolation confine any remaining trust to owner-created streaming campaigns).
- Cross-language leaf spec pinned by **golden vectors** in `src/merkle.rs` (`sha256("{addr}:{cumulative}")`, sorted-pair parents) — the TS tree-builder for the keeper/frontends must match these byte-for-byte.
- **Native denoms only** (tokenfactory/IBC/erc20:*) — plain `cosmwasm-std` 2.2.2, no `injective-std`, no CW20 receive hooks.
- **25 unit tests**, clippy clean, builds to wasm. Schema committed under `schema/`.
- Deliberately deferred: URD-style root-update timelock for streaming (migrate to add if a streaming campaign ever holds serious float; the contract sits behind `choice_admin_timelock`), claim-on-behalf, batch `Claimable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)