### PR TITLE
feat(mts-issuer): brand launch denoms with the creator's name and symbol (1.0.0 -> 1.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "choice-mts-issuer"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "choice",
  "choice-clmm-common",

--- a/contracts/choice_mts_issuer/Cargo.toml
+++ b/contracts/choice_mts_issuer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "choice-mts-issuer"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Dan Van Eijck"]
 edition = "2021"
 description = "Generic MultiVM Token Standard issuer + reserve custodian. Per-dApp instantiated; pairs a tokenfactory denom to an auto-deployed MintBurnBankERC20 and delivers the CW-side reserve to a pool seeder at graduation."

--- a/contracts/choice_mts_issuer/schema/execute_msg.json
+++ b/contracts/choice_mts_issuer/schema/execute_msg.json
@@ -84,6 +84,22 @@
               "description": "Seeder factory bech32 the consumer dApp instantiated (a `choice_pool_seeder` factory). The issuer forwards `create_sink_payload` to this contract during registration.",
               "type": "string"
             },
+            "token_name": {
+              "description": "Human-facing token name written into the launch denom's bank metadata at `MsgCreateDenom` (and therefore inherited by the auto-deployed `MintBurnBankERC20` pair, which reads its `name()` from bank metadata at `MsgCreateTokenPair`).\n\n`None` (or an all-whitespace string) falls back to the raw subdenom — the pre-1.1 behaviour, which branded every token `shroom_42_aB3xK9zQ` / `SHROOM_42_AB3XK9ZQ` on every explorer.\n\nTHIS IS A ONE-SHOT FIELD. The chain finalises `decimals` at create time, and the issuer renounces the denom's tokenfactory admin to the dead address at `RenounceDenomAdmin`; after that no `MsgSetDenomMetadata` can ever land (the admin is non-empty, so the governance path is closed too). Whatever is passed here is the token's on-chain name forever — the contract therefore validates strictly and refuses the launch rather than branding it with something malformed. See [`crate::contract::MAX_TOKEN_NAME_LEN`].",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "token_symbol": {
+              "description": "Human-facing ticker for the same bank metadata. Same fallback and same one-shot permanence as `token_name`; capped tighter (see [`crate::contract::MAX_TOKEN_SYMBOL_LEN`]) because a 64-char ticker is never legitimate and wrecks every table that renders it.",
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "total_supply": {
               "description": "= `evm_supply` + `cw_held`. Both halves are minted up front to keep downstream amounts straight.",
               "allOf": [

--- a/contracts/choice_mts_issuer/src/contract.rs
+++ b/contracts/choice_mts_issuer/src/contract.rs
@@ -50,6 +50,21 @@ pub const MAX_SUBDENOM_LEN: usize = 44;
 /// 44-char subdenom cap (`MAX_SUBDENOM_LEN`), checked after concatenation.
 pub const MIN_SALT_SUFFIX_LEN: usize = 8;
 
+/// Caps on the creator-supplied bank-metadata branding (`token_name` /
+/// `token_symbol` on [`crate::msg::ExecuteMsg::RegisterLaunch`]).
+///
+/// The chain's own limits are 64 bytes for BOTH (`MaxNameLength` /
+/// `MaxSymbolLength` in `injective-chain/modules/tokenfactory/types/denoms.go`)
+/// and it rejects the whole `MsgCreateDenom` above them — which would revert an
+/// otherwise-good launch deep in the dispatch chain with a chain-side error the
+/// keeper can't act on. We validate here so the failure is typed and local.
+///
+/// The name cap matches the chain exactly; the symbol cap is deliberately
+/// tighter — a 64-char ticker is never legitimate, and it is the field every
+/// table, chart axis and wallet row renders in a fixed-width slot.
+pub const MAX_TOKEN_NAME_LEN: usize = 64;
+pub const MAX_TOKEN_SYMBOL_LEN: usize = 32;
+
 /// Cap registration's decimals at the EVM ERC20 norm. MTS pairing inherits
 /// this on the EVM side, so anything > 18 risks the auto-deployed
 /// `MintBurnBankERC20` failing on construction. Matches the chain-side cap.
@@ -189,6 +204,93 @@ fn validate_subdenom_prefix(prefix: &str) -> Result<(), ContractError> {
     Ok(())
 }
 
+/// Resolve the bank-metadata `name` / `symbol` the launch denom is created
+/// with, from the keeper-relayed creator branding.
+///
+/// Returns the pre-1.1 values (`subdenom` / `SUBDENOM`) when the caller supplies
+/// nothing, so an older keeper — or a `RegisterLaunch` already in the mempool
+/// when this code migrates in — keeps working unchanged rather than failing.
+///
+/// Rejects rather than sanitises. `MsgCreateDenom` is the ONLY write: the chain
+/// finalises `decimals` at create time and `RenounceDenomAdmin` hands the
+/// tokenfactory admin to the dead address, after which
+/// `SetDenomMetadata` is refused for both the admin path (sender must equal the
+/// dead address) and the governance path (which requires an EMPTY admin). A bad
+/// value is therefore permanent, and a launch the keeper can retry after a fix
+/// is strictly better than a token branded wrong forever.
+fn resolve_denom_branding(
+    subdenom: &str,
+    token_name: Option<String>,
+    token_symbol: Option<String>,
+) -> Result<(String, String), ContractError> {
+    let name = validate_branding(token_name, "name", MAX_TOKEN_NAME_LEN)?
+        .unwrap_or_else(|| subdenom.to_string());
+    let symbol = validate_branding(token_symbol, "symbol", MAX_TOKEN_SYMBOL_LEN)?
+        .unwrap_or_else(|| subdenom.to_uppercase());
+    Ok((name, symbol))
+}
+
+/// `None` / blank ⇒ `Ok(None)` (caller substitutes the subdenom fallback).
+/// Anything present must be short enough for the chain's cap and free of
+/// characters that don't render as themselves.
+fn validate_branding(
+    raw: Option<String>,
+    field: &str,
+    max_len: usize,
+) -> Result<Option<String>, ContractError> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let value = raw.trim();
+    if value.is_empty() {
+        // An explicitly-empty string means "no branding", identical to `None`.
+        // The chain would accept it (only the length is checked) and every
+        // explorer would then render a nameless token.
+        return Ok(None);
+    }
+    // Byte length, not chars: the chain's `MaxNameLength` / `MaxSymbolLength`
+    // are `len(m.Name)` over the UTF-8 bytes, so a 30-emoji name is over cap
+    // even though it is 30 chars.
+    if value.len() > max_len {
+        return Err(ContractError::TokenBrandingInvalid {
+            field: field.to_string(),
+            got: value.to_string(),
+            reason: format!("{} bytes exceeds the {}-byte cap", value.len(), max_len),
+        });
+    }
+    if let Some(bad) = value.chars().find(|c| !is_renderable_branding_char(*c)) {
+        return Err(ContractError::TokenBrandingInvalid {
+            field: field.to_string(),
+            got: value.to_string(),
+            reason: format!(
+                "contains the non-rendering character U+{:04X} (control, zero-width or bidi override)",
+                bad as u32
+            ),
+        });
+    }
+    Ok(Some(value.to_string()))
+}
+
+/// Reject characters that do not render as themselves. Two classes:
+///   * C0/C1 controls — newlines and NULs inside a token name corrupt every
+///     log line, CSV export and terminal that prints it.
+///   * Zero-width and bidi-override formatting — the classic homograph vector:
+///     `U+202E` makes `MOORHS` render as `SHROOM`, and `U+200B` lets two
+///     visually identical tickers coexist. Unicode NAMES stay allowed (the FE
+///     deliberately UTF-8-encodes so emoji/non-latin survive); only characters
+///     whose whole purpose is to disagree with their glyph are refused.
+fn is_renderable_branding_char(c: char) -> bool {
+    if c.is_control() {
+        return false;
+    }
+    !matches!(c,
+        '\u{200B}'..='\u{200F}'   // zero-width space/joiners, LRM/RLM
+        | '\u{202A}'..='\u{202E}' // bidi embedding + overrides
+        | '\u{2066}'..='\u{2069}' // bidi isolates
+        | '\u{FEFF}'              // zero-width no-break space (BOM)
+    )
+}
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut<InjectiveQueryWrapper>,
@@ -209,6 +311,8 @@ pub fn execute(
             choice_factory,
             salt_suffix,
             clmm_pool_auth,
+            token_name,
+            token_symbol,
         } => execute_register_launch(
             deps,
             env,
@@ -224,6 +328,8 @@ pub fn execute(
             choice_factory,
             salt_suffix,
             clmm_pool_auth,
+            token_name,
+            token_symbol,
         ),
         ExecuteMsg::DeliverToSeeder {
             evm_authority,
@@ -274,6 +380,8 @@ fn execute_register_launch(
     choice_factory: Option<String>,
     salt_suffix: Option<String>,
     clmm_pool_auth: Option<ClmmPoolAuth>,
+    token_name: Option<String>,
+    token_symbol: Option<String>,
 ) -> Result<Response<InjectiveMsgWrapper>, ContractError> {
     let config = CONFIG.load(deps.storage)?;
 
@@ -391,6 +499,13 @@ fn execute_register_launch(
         });
     }
     let denom = format!("factory/{}/{}", env.contract.address, subdenom);
+
+    // Bank-metadata branding for the denom created below. Resolved (and
+    // refused, if malformed) HERE rather than at the dispatch site: this is the
+    // last cheap point to fail — everything past it decodes payloads and
+    // derives addresses — and a chain-side rejection of `MsgCreateDenom` would
+    // otherwise unwind the entire launch with an untyped error.
+    let (denom_name, denom_symbol) = resolve_denom_branding(&subdenom, token_name, token_symbol)?;
 
     // The pair asset must differ from the freshly-minted launch denom. A
     // self-paired pool is degenerate and would fail (or mis-seed) at the
@@ -597,29 +712,40 @@ fn execute_register_launch(
     submsgs.push(SubMsg::new(CosmosMsg::from(MsgCreateDenom {
         sender: env.contract.address.to_string(),
         subdenom: subdenom.clone(),
-        name: subdenom.clone(),
-        symbol: subdenom.to_uppercase(),
+        name: denom_name.clone(),
+        symbol: denom_symbol.clone(),
         decimals: config.decimals,
         allow_admin_burn: true,
     })));
 
-    // 2. (removed) SetTokenMetadata.
+    // 2. (deliberately absent) SetDenomMetadata.
     //
-    // injectived v1.20+ `MsgCreateDenom` finalises decimals at create-time,
-    // and a follow-up `MsgSetDenomMetadata` with the same decimals errors
-    // out with "cannot update denom metadata decimals". Empirically
-    // observed on testnet 2026-05-26 (tx 52D5873E…). The decimals are
-    // already on-chain from step 1; name/symbol on the chain-side metadata
-    // can be set later via a separate, decimals-free path if needed
-    // (cosmetic only — choice_factory uses its own NATIVE_TOKEN_DECIMALS
-    // map, registered via step 5 below).
+    // Step 1 is the ONLY metadata write, by design — the branding rides on
+    // `MsgCreateDenom` itself rather than a follow-up. Two reasons it must stay
+    // that way:
     //
-    // ACCEPTED TRADEOFF (cosmetic): `MsgCreateDenom` below sets the bank
-    // metadata `name`/`symbol` to the raw subdenom (e.g. `shroom_42_aB3xK9zQ`),
-    // and the v1.20 decimals-immutability trap means it can't be prettied up
-    // post-create. Bank explorers will show that raw form. The human-facing
-    // name/symbol live on the EVM-side MTS pair and in the app, so this is
-    // knowingly left as-is rather than worked around.
+    //   * `MsgCreateDenom` finalises `decimals` (v1.20+), and the chain's
+    //     `SetDenomMetadata` handler rejects any submission whose decimals
+    //     disagree with what is already stored. A same-decimals write IS
+    //     accepted by the current handler, but a testnet probe on 2026-05-26
+    //     (tx 52D5873E…) hit the rejection, so the path is not one to depend on
+    //     inside a launch that would unwind with it.
+    //   * `RenounceDenomAdmin` (C-M2) hands the tokenfactory admin to the dead
+    //     address, and the chain gates `SetDenomMetadata` on `sender == admin`
+    //     OR (`admin == ""` AND sender is governance). A dead-but-non-empty
+    //     admin closes BOTH, so after renounce the metadata is frozen for
+    //     everyone, permanently.
+    //
+    // Pre-1.1 this step's absence meant the token was branded with its raw
+    // subdenom (`shroom_42_aB3xK9zQ` / `SHROOM_42_AB3XK9ZQ`) on every explorer
+    // AND on the auto-deployed ERC20 pair, which reads `name()`/`symbol()` from
+    // this same bank metadata at step 4. `token_name`/`token_symbol` fix that at
+    // the only moment the chain will still accept them.
+    //
+    // Still NOT set (no write path exists post-create): `display`, `description`
+    // and `uri`. They have been empty for every launch to date; the app and the
+    // EVM-side `metadataURI` carry that content. `choice_factory` reads decimals
+    // from its own NATIVE_TOKEN_DECIMALS map (step 5), never from here.
 
     // 3. Mint full total_supply to self. cw_held stays here (minus 1 wei
     //    dust if step 5 fires); evm_supply is bank-sent out at step 6.
@@ -724,6 +850,12 @@ fn execute_register_launch(
         .add_attribute("action", "register_launch")
         .add_attribute("internal_id", internal_id.to_string())
         .add_attribute("denom", denom)
+        // The branding actually written to bank metadata — emitted so the
+        // watchdog can assert it against the EVM `metadataURI` without a
+        // bank query, and so an indexer can tell a real name apart from the
+        // subdenom fallback.
+        .add_attribute("denom_name", denom_name)
+        .add_attribute("denom_symbol", denom_symbol)
         .add_attribute("evm_authority", evm_authority)
         .add_attribute("total_supply", total_supply)
         .add_attribute("evm_supply", evm_supply)

--- a/contracts/choice_mts_issuer/src/error.rs
+++ b/contracts/choice_mts_issuer/src/error.rs
@@ -58,6 +58,15 @@ pub enum ContractError {
         max: usize,
     },
 
+    #[error(
+        "token_{field} `{got}` is invalid: {reason}. The denom's bank metadata is written once at MsgCreateDenom and is immutable after RenounceDenomAdmin, so a malformed value would brand the token permanently — refusing the launch instead. Fix the value and re-register."
+    )]
+    TokenBrandingInvalid {
+        field: String,
+        got: String,
+        reason: String,
+    },
+
     #[error("Decimals {got} out of range (must be 0..=18)")]
     DecimalsOutOfRange { got: u32 },
 

--- a/contracts/choice_mts_issuer/src/msg.rs
+++ b/contracts/choice_mts_issuer/src/msg.rs
@@ -112,6 +112,31 @@ pub enum ExecuteMsg {
         /// `ttl_seconds = 0` (no expiry) for graduations. `None` skips the
         /// reservation (e.g. legacy XYK graduations).
         clmm_pool_auth: Option<ClmmPoolAuth>,
+        /// Human-facing token name written into the launch denom's bank
+        /// metadata at `MsgCreateDenom` (and therefore inherited by the
+        /// auto-deployed `MintBurnBankERC20` pair, which reads its `name()`
+        /// from bank metadata at `MsgCreateTokenPair`).
+        ///
+        /// `None` (or an all-whitespace string) falls back to the raw subdenom
+        /// — the pre-1.1 behaviour, which branded every token
+        /// `shroom_42_aB3xK9zQ` / `SHROOM_42_AB3XK9ZQ` on every explorer.
+        ///
+        /// THIS IS A ONE-SHOT FIELD. The chain finalises `decimals` at create
+        /// time, and the issuer renounces the denom's tokenfactory admin to the
+        /// dead address at `RenounceDenomAdmin`; after that no
+        /// `MsgSetDenomMetadata` can ever land (the admin is non-empty, so the
+        /// governance path is closed too). Whatever is passed here is the
+        /// token's on-chain name forever — the contract therefore validates
+        /// strictly and refuses the launch rather than branding it with
+        /// something malformed. See [`crate::contract::MAX_TOKEN_NAME_LEN`].
+        #[serde(default)]
+        token_name: Option<String>,
+        /// Human-facing ticker for the same bank metadata. Same fallback and
+        /// same one-shot permanence as `token_name`; capped tighter (see
+        /// [`crate::contract::MAX_TOKEN_SYMBOL_LEN`]) because a 64-char ticker
+        /// is never legitimate and wrecks every table that renders it.
+        #[serde(default)]
+        token_symbol: Option<String>,
     },
 
     /// Keeper-relayed after the EVM authority emits `BootstrapReady(internal_id,

--- a/contracts/choice_mts_issuer/src/tests.rs
+++ b/contracts/choice_mts_issuer/src/tests.rs
@@ -28,7 +28,7 @@ use injective_cosmwasm::{InjectiveMsg, InjectiveRoute};
 
 use crate::contract::{
     execute, instantiate, migrate, query, reply, MAX_DECIMALS, MAX_SUBDENOM_PREFIX_LEN,
-    MIN_REFUND_DEADLINE_SECONDS,
+    MAX_TOKEN_NAME_LEN, MAX_TOKEN_SYMBOL_LEN, MIN_REFUND_DEADLINE_SECONDS,
 };
 use crate::error::ContractError;
 use crate::msg::{
@@ -116,11 +116,39 @@ fn register_with_choice_factory(
     internal_id: u64,
     choice_factory: Option<String>,
 ) -> Result<cosmwasm_std::Response<injective_cosmwasm::InjectiveMsgWrapper>, ContractError> {
+    register_with_opts(deps, internal_id, choice_factory, None, None)
+}
+
+/// Register with creator-supplied bank-metadata branding (the 1.1 fields).
+fn register_with_branding(
+    deps: &mut Deps,
+    internal_id: u64,
+    token_name: Option<&str>,
+    token_symbol: Option<&str>,
+) -> Result<cosmwasm_std::Response<injective_cosmwasm::InjectiveMsgWrapper>, ContractError> {
+    register_with_opts(
+        deps,
+        internal_id,
+        None,
+        token_name.map(str::to_string),
+        token_symbol.map(str::to_string),
+    )
+}
+
+fn register_with_opts(
+    deps: &mut Deps,
+    internal_id: u64,
+    choice_factory: Option<String>,
+    token_name: Option<String>,
+    token_symbol: Option<String>,
+) -> Result<cosmwasm_std::Response<injective_cosmwasm::InjectiveMsgWrapper>, ContractError> {
     let caller = deps.api.addr_make("keeper");
     let info = message_info(&caller, &fee_funds());
     // salt_suffix is mandatory now; the sink payload's token_denom must embed it.
     let payload = xyk_sink_payload(deps, internal_id);
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name,
+        token_symbol,
         internal_id,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         // 1B tokens * 1e18 = 1e27
@@ -431,6 +459,14 @@ fn register_launch_emits_expected_message_chain_and_persists_record() {
                 "Path B Leg A requires admin burn-from"
             );
             assert_eq!(decoded.decimals, 18);
+            // No branding supplied ⇒ pre-1.1 fallback, so an older keeper (or a
+            // RegisterLaunch already in flight across the migration) is
+            // byte-identical to what it was before.
+            assert_eq!(decoded.name, format!("{}_{}_{}", PREFIX, 42, TEST_SALT));
+            assert_eq!(
+                decoded.symbol,
+                format!("{}_{}_{}", PREFIX, 42, TEST_SALT).to_uppercase()
+            );
         }
         other => panic!("expected Stargate CreateDenom, got {:?}", other),
     }
@@ -501,6 +537,177 @@ fn register_launch_emits_expected_message_chain_and_persists_record() {
     assert_eq!(stored.erc20_address, None, "filled in by reply handler");
 }
 
+/// Decode the `MsgCreateDenom` out of a `RegisterLaunch` response. The
+/// branding tests all assert on the same message, and it is always the first
+/// `ReplyOn::Never` submessage (step 1 of the dispatch chain).
+fn decoded_create_denom(
+    res: &cosmwasm_std::Response<injective_cosmwasm::InjectiveMsgWrapper>,
+) -> MsgCreateDenom {
+    #[allow(deprecated)]
+    let msg = res
+        .messages
+        .iter()
+        .filter(|sm| sm.reply_on == ReplyOn::Never)
+        .find_map(|sm| match &sm.msg {
+            CosmosMsg::Stargate { type_url, value } if type_url == MsgCreateDenom::TYPE_URL => {
+                Some(MsgCreateDenom::decode(value.as_slice()).unwrap())
+            }
+            _ => None,
+        });
+    msg.expect("RegisterLaunch must dispatch a MsgCreateDenom")
+}
+
+#[test]
+fn register_launch_brands_denom_with_creator_name_and_symbol() {
+    let mut deps = setup();
+    let res = register_with_branding(&mut deps, 42, Some("Shroomi Coin"), Some("SHRM")).unwrap();
+
+    // The whole point of the 1.1 migration: the creator's branding is what the
+    // chain stores, not `shroom_42_<salt>`. The auto-deployed MintBurnBankERC20
+    // reads `name()`/`symbol()` from this same bank metadata at
+    // MsgCreateTokenPair, so this fixes the ERC20 pair in the same stroke.
+    let decoded = decoded_create_denom(&res);
+    assert_eq!(decoded.name, "Shroomi Coin");
+    assert_eq!(decoded.symbol, "SHRM");
+    // Subdenom is untouched — the denom string is Layer A entropy, not branding.
+    assert_eq!(decoded.subdenom, format!("{}_{}_{}", PREFIX, 42, TEST_SALT));
+
+    let attrs: Vec<_> = res
+        .attributes
+        .iter()
+        .filter(|a| a.key == "denom_name" || a.key == "denom_symbol")
+        .map(|a| (a.key.as_str(), a.value.as_str()))
+        .collect();
+    assert_eq!(
+        attrs,
+        vec![("denom_name", "Shroomi Coin"), ("denom_symbol", "SHRM")]
+    );
+}
+
+#[test]
+fn register_launch_accepts_unicode_branding() {
+    let mut deps = setup();
+    // The FE UTF-8-encodes metadata precisely so emoji/non-latin names survive;
+    // refusing them here would silently downgrade those launches to the raw
+    // subdenom. Only non-RENDERING characters are refused, not non-latin ones.
+    let res = register_with_branding(&mut deps, 42, Some("🍄 Шруми"), Some("ШРМ")).unwrap();
+    let decoded = decoded_create_denom(&res);
+    assert_eq!(decoded.name, "🍄 Шруми");
+    assert_eq!(decoded.symbol, "ШРМ");
+}
+
+#[test]
+fn register_launch_trims_branding_and_falls_back_when_blank() {
+    let mut deps = setup();
+    let res = register_with_branding(&mut deps, 42, Some("  Shroomi  "), Some("   ")).unwrap();
+    let decoded = decoded_create_denom(&res);
+    assert_eq!(decoded.name, "Shroomi", "surrounding whitespace is trimmed");
+    // An all-whitespace symbol is treated as "absent", not stored as blank —
+    // the chain would accept `"   "` and every explorer would render nothing.
+    assert_eq!(
+        decoded.symbol,
+        format!("{}_{}_{}", PREFIX, 42, TEST_SALT).to_uppercase()
+    );
+}
+
+#[test]
+fn register_launch_rejects_overlong_token_name() {
+    let mut deps = setup();
+    let long = "a".repeat(MAX_TOKEN_NAME_LEN + 1);
+    let err = register_with_branding(&mut deps, 42, Some(&long), None).unwrap_err();
+    match err {
+        ContractError::TokenBrandingInvalid { field, .. } => assert_eq!(field, "name"),
+        other => panic!("expected TokenBrandingInvalid, got {:?}", other),
+    }
+}
+
+#[test]
+fn register_launch_rejects_overlong_token_symbol() {
+    let mut deps = setup();
+    // Under the chain's own 64-byte cap but over ours: the tighter symbol
+    // bound is this contract's, and it must actually bite.
+    let long = "S".repeat(MAX_TOKEN_SYMBOL_LEN + 1);
+    assert!(long.len() < 64);
+    let err = register_with_branding(&mut deps, 42, None, Some(&long)).unwrap_err();
+    match err {
+        ContractError::TokenBrandingInvalid { field, .. } => assert_eq!(field, "symbol"),
+        other => panic!("expected TokenBrandingInvalid, got {:?}", other),
+    }
+}
+
+#[test]
+fn register_launch_counts_branding_in_bytes_not_chars() {
+    let mut deps = setup();
+    // 17 four-byte emoji = 68 bytes = over the 64-byte name cap, but only 17
+    // chars. The chain measures `len(m.Name)` in bytes, so a char-based check
+    // here would pass the launch straight into a chain-side rejection.
+    let emoji = "🍄".repeat(17);
+    assert!(emoji.chars().count() < MAX_TOKEN_NAME_LEN && emoji.len() > MAX_TOKEN_NAME_LEN);
+    let err = register_with_branding(&mut deps, 42, Some(&emoji), None).unwrap_err();
+    assert!(matches!(err, ContractError::TokenBrandingInvalid { .. }));
+}
+
+#[test]
+fn register_launch_rejects_non_rendering_branding() {
+    // U+202E RIGHT-TO-LEFT OVERRIDE renders the following text reversed — the
+    // classic homograph trick for making one token look like another. Bank
+    // metadata is immutable after RenounceDenomAdmin, so this has to be caught
+    // before the denom exists, not audited afterwards.
+    for (name, symbol) in [
+        (Some("SHROOM\u{202E}NIOC"), None),
+        (Some("Shroomi\nInc"), None),
+        (None, Some("SH\u{200B}RM")),
+    ] {
+        let mut deps = setup();
+        let err = register_with_branding(&mut deps, 42, name, symbol).unwrap_err();
+        match err {
+            ContractError::TokenBrandingInvalid { reason, .. } => {
+                assert!(
+                    reason.contains("non-rendering"),
+                    "expected a non-rendering-char rejection, got: {reason}"
+                );
+            }
+            other => panic!("expected TokenBrandingInvalid, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn register_launch_msg_deserialises_without_branding_fields() {
+    // MIGRATION-WINDOW GUARD. Between the MsgMigrateContract and the keeper
+    // redeploy, the live keeper still sends the 1.0 payload — and any
+    // RegisterLaunch already in the mempool at migrate time carries it too. If
+    // these fields were not `#[serde(default)]`, every one of those launches
+    // would fail to deserialise and brick until the keeper caught up.
+    let wire = br#"{
+        "register_launch": {
+            "internal_id": 7,
+            "evm_authority": "inj1evmauthority",
+            "total_supply": "1000",
+            "evm_supply": "800",
+            "pair_denom": "inj",
+            "seeder_factory": "inj1seederfactory",
+            "seeder_addr": "inj1seederaddr",
+            "create_sink_payload": "e30=",
+            "choice_factory": null,
+            "salt_suffix": "abcdefgh",
+            "clmm_pool_auth": null
+        }
+    }"#;
+    let parsed: ExecuteMsg = from_json(wire).expect("1.0 payload must still parse");
+    match parsed {
+        ExecuteMsg::RegisterLaunch {
+            token_name,
+            token_symbol,
+            ..
+        } => {
+            assert_eq!(token_name, None);
+            assert_eq!(token_symbol, None);
+        }
+        other => panic!("expected RegisterLaunch, got {:?}", other),
+    }
+}
+
 #[test]
 fn register_launch_rejects_duplicate_internal_id() {
     let mut deps = setup();
@@ -518,6 +725,8 @@ fn register_launch_rejects_zero_total_supply() {
     let caller = deps.api.addr_make("keeper");
     let info = message_info(&caller, &fee_funds());
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 1,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::zero(),
@@ -540,6 +749,8 @@ fn register_launch_rejects_evm_supply_over_total() {
     let caller = deps.api.addr_make("keeper");
     let info = message_info(&caller, &fee_funds());
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 1,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(100),
@@ -563,6 +774,8 @@ fn register_launch_rejects_when_caller_omits_create_fee_funds() {
     // No `info.funds` attached → caller didn't pay the chain's create fee.
     let info = message_info(&caller, &[]);
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 1,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000),
@@ -591,6 +804,8 @@ fn register_launch_rejects_overpaid_create_fee() {
     // the contract's bank balance.
     let info = message_info(&caller, &[coin(CREATE_FEE + 13, CREATE_FEE_DENOM)]);
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 70,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),
@@ -622,6 +837,8 @@ fn register_launch_rejects_unexpected_funds_denom() {
         ],
     );
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 71,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),
@@ -689,6 +906,8 @@ fn register_launch_rejects_choice_factory_when_cw_held_is_zero() {
     let caller = deps.api.addr_make("keeper");
     let info = message_info(&caller, &fee_funds());
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 60,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         // total == evm → cw_held = 0 → no dust available
@@ -1306,6 +1525,8 @@ fn register_launch_rejects_non_keeper() {
     let stranger = deps.api.addr_make("stranger");
     let info = message_info(&stranger, &fee_funds());
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 1,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000),
@@ -1347,6 +1568,8 @@ fn two_authorities_share_internal_id_without_record_collision() {
             auth,
         );
         let msg = ExecuteMsg::RegisterLaunch {
+            token_name: None,
+            token_symbol: None,
             internal_id: 0,
             evm_authority: auth.clone(),
             total_supply: Uint128::new(1_000_000),
@@ -1670,6 +1893,8 @@ fn register_full(
         deps.api.addr_make("evm_authority").as_ref(),
     );
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),
@@ -1888,6 +2113,8 @@ fn register_raw(
     let caller = deps.api.addr_make("keeper");
     let info = message_info(&caller, &fee_funds());
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),
@@ -2250,6 +2477,8 @@ fn register_with_seeder(
     let info = message_info(&caller, &fee_funds());
     let payload = salted_xyk_payload(deps, internal_id, salt_suffix);
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),
@@ -2354,6 +2583,8 @@ fn register_launch_rejects_refund_receiver_mismatch() {
         deps.api.addr_make("attacker").as_ref(),
     );
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id: 5,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),
@@ -2439,6 +2670,8 @@ fn register_clmm_verify(
     let info = message_info(&caller, &fee_funds());
     let payload = salted_clmm_payload(deps, internal_id, salt_suffix, position_recipient);
     let msg = ExecuteMsg::RegisterLaunch {
+        token_name: None,
+        token_symbol: None,
         internal_id,
         evm_authority: deps.api.addr_make("evm_authority").to_string(),
         total_supply: Uint128::new(1_000_000_000u128) * Uint128::new(10u128.pow(18)),


### PR DESCRIPTION
## The problem

`MsgCreateDenom` has carried `name` and `symbol` since injectived v1.20, but the issuer fills both with the raw subdenom. Live mainnet, launch 13:

```
bank metadata:  name   "shroom_13_f9ac767ba1df1fec"
                symbol "SHROOM_13_F9AC767BA1DF1FEC"
MTS ERC20 0xfd02…0974: name()/symbol() return the same strings
```

That token is **SKIBIDI / SKIBI**. The real branding lives only in the EVM `metadataURI` and in the app. The ERC20 pair inherits the bad values because it reads name/symbol from bank metadata at `MsgCreateTokenPair`, so both surfaces are wrong from one root cause.

## The fix

`RegisterLaunch` gains `token_name` / `token_symbol`, passed straight to `MsgCreateDenom`. No new message, no new proto, no `SetDenomMetadata`. The keeper decodes them from the launch's own `metadataURI` (companion PR in `shroom_launchpad`).

## Why it rejects instead of sanitising

`MsgCreateDenom` is the only write. The chain finalises `decimals` at create time, and `RenounceDenomAdmin` hands the tokenfactory admin to the dead address — after which the chain refuses `SetDenomMetadata` from the admin path (`sender` must equal the dead address) *and* the governance path (which needs an **empty** admin). A bad value is permanent. A launch the keeper can retry after a fix beats a token branded wrong forever.

Validation mirrors the chain: caps in **UTF-8 bytes** (name 64 = `MaxNameLength`; symbol 32, tighter on purpose), and a refusal of characters that don't render as themselves — controls, zero-width formatting, bidi overrides. U+202E makes `MOORHS` display as `SHROOM`, and bank metadata can't be audited after the fact. Unicode names stay allowed; the FE UTF-8-encodes precisely so emoji and non-latin names survive.

## Migration safety

Version `1.0.0` -> `1.1.0` — same major, so `MigrateMsg::Patch {}` applies. Message schema only; no `LaunchRecord` state delta.

Deploy order doesn't matter:

| | old keeper | new keeper |
| --- | --- | --- |
| **issuer 1.0** | today | serde drops the 2 unknown fields (no `deny_unknown_fields`) |
| **issuer 1.1** | `#[serde(default)]` -> `None` -> subdenom fallback | branding lands |

Neither half can break the other. There's a regression test asserting the 1.0 wire payload still deserialises, because the migration window has the live keeper sending it.

## Tests

74 pass (8 new): branding pass-through, unicode, trim/blank fallback, over-cap name, over-cap symbol, byte-vs-char counting, non-rendering characters, and 1.0 wire compatibility. Clippy and fmt clean; `schema/execute_msg.json` regenerated (both fields `"default": null`, neither in `required`).

## Rollout

Mainnet is a **48 h timelocked** migrate (`inj14tm9kjh…`), so this is not a same-day change. Full runbook, including the trap that the deployed timelock is an older migration-only build than the one in this repo: `docs/ISSUER_1.1_METADATA_MIGRATION.md` in `shroom_launchpad`.

⚠️ **Does not fix the 15 existing mainnet tokens.** Their denom admin is already renounced; they are branded as they are, permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)