### PR TITLE
feat(mts-issuer): hand the denom admin to the ERC20 so holders can burn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "choice-mts-issuer"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "choice",
  "choice-clmm-common",

--- a/contracts/choice_mts_issuer/Cargo.toml
+++ b/contracts/choice_mts_issuer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "choice-mts-issuer"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Dan Van Eijck"]
 edition = "2021"
 description = "Generic MultiVM Token Standard issuer + reserve custodian. Per-dApp instantiated; pairs a tokenfactory denom to an auto-deployed MintBurnBankERC20 and delivers the CW-side reserve to a pool seeder at graduation."

--- a/contracts/choice_mts_issuer/schema/execute_msg.json
+++ b/contracts/choice_mts_issuer/schema/execute_msg.json
@@ -180,13 +180,41 @@
       "additionalProperties": false
     },
     {
-      "description": "Keeper-or-admin, post-`Delivered`: relinquish this contract's tokenfactory admin over the launch denom by rotating the admin to the 20-zero-byte burn-address convention via `MsgChangeAdmin` (finding C-M2). After this the issuer can no longer `MsgMint` new supply or admin-`MsgBurn`-from holders for the denom.\n\nNOTE: this renounces the *tokenfactory* admin only. The auto-deployed `MintBurnBankERC20` owner is the issuer's lower-20-byte EVM address; a CosmWasm contract cannot sign the EVM tx to renounce that ERC20 ownership, so that step must be performed separately by the issuer's controller on the EVM side (deployment runbook item).",
+      "description": "Keeper-or-admin, post-`Delivered`: relinquish this contract's tokenfactory admin over the launch denom via `MsgChangeAdmin` (finding C-M2). After this the issuer can no longer `MsgMint` new supply or admin-`MsgBurn`-from holders for the denom.\n\n🔴 **As of 1.2.0 the admin goes to the launch's own paired ERC20, not to the 20-zero-byte burn address.** Both relinquish this contract's powers, which is all C-M2 asked for, but the dead address ALSO forecloses every holder burn forever — `verifyBurnFromPermissions` requires `admin == the ERC20 contract`, and `MsgChangeAdmin` needs the current admin to sign, so there is no way back. Nine mainnet launch denoms are already stranded that way. See [`ExecuteMsg::HandOverDenomAdminToErc20`], which this now mirrors.\n\nNOTE: this relinquishes the *tokenfactory* admin only. The auto-deployed `MintBurnBankERC20` owner is the issuer's lower-20-byte EVM address; a CosmWasm contract cannot sign the EVM tx to renounce that ERC20 ownership. That is harmless here — the owner is an address with no private key, and there is no wasm→EVM call path on Injective for this contract to reach `mint` through — but a keeper EOA issuing its own tokens MUST renounce, because then the owner is a real signer.",
       "type": "object",
       "required": [
         "renounce_denom_admin"
       ],
       "properties": {
         "renounce_denom_admin": {
+          "type": "object",
+          "required": [
+            "evm_authority",
+            "internal_id"
+          ],
+          "properties": {
+            "evm_authority": {
+              "type": "string"
+            },
+            "internal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Keeper-or-admin: hand this denom's tokenfactory admin to its OWN paired `MintBurnBankERC20`, which is what makes the token burnable by its holders.\n\n## Why this exists\n\n`evm/precompiles/bank/bank.go:mintBurn` turns a holder's `burn(uint256)` on a `factory/…`-backed ERC20 into `MsgBurn{ Sender: <the ERC20 contract>, BurnFromAddress: <the holder> }`. `Sender != BurnFrom`, so it is not a self-burn, so `tokenfactory/keeper/burn_permissions.go:verifyBurnFromPermissions` demands BOTH `AdminBurnAllowed == true` AND **`admin == the ERC20 contract`**. `RegisterLaunch` sets `allow_admin_burn = true` but leaves the admin as THIS CONTRACT, so every launch token issued to date reverts `unauthorized account` on a holder burn — and, by the same asymmetry, on `mint`.\n\nThis message sends the missing `MsgChangeAdmin(denom, bech32(erc20_address))`. Measured on testnet 2026-09-06: with it, a holder burn reduces real bank supply; without it, nothing can.\n\n## What it costs\n\nAfter the rotation this contract is no longer the denom admin, so it can no longer `MsgMint` or admin-`MsgBurn` — the same terminal property [`ExecuteMsg::RenounceDenomAdmin`] was written to guarantee, which is why both set `admin_renounced`. The mint gate moves to the ERC20's `Ownable` owner, which is this contract's own 20-byte EVM mirror: an address with no private key, and unreachable from CosmWasm because Injective has no wasm→EVM call path (the precompile set is bank / bindings / exchange / oracle / staking). So mint stays dead, and burn opens.\n\n⛔ **Only available while this contract is still the admin.** Once the admin is the dead address, `MsgChangeAdmin` needs a signature nobody holds and the denom is permanently unburnable. Any residual balance is burnt first, exactly as `RenounceDenomAdmin` does, because that is also the last moment a self-burn is possible.",
+      "type": "object",
+      "required": [
+        "hand_over_denom_admin_to_erc20"
+      ],
+      "properties": {
+        "hand_over_denom_admin_to_erc20": {
           "type": "object",
           "required": [
             "evm_authority",

--- a/contracts/choice_mts_issuer/schema/launch_response.json
+++ b/contracts/choice_mts_issuer/schema/launch_response.json
@@ -18,7 +18,7 @@
   ],
   "properties": {
     "admin_renounced": {
-      "description": "`true` once `RenounceDenomAdmin` has relinquished this contract's tokenfactory admin over the denom (finding C-M2).",
+      "description": "`true` once `RenounceDenomAdmin` or `HandOverDenomAdminToErc20` has relinquished this contract's tokenfactory admin over the denom (finding C-M2). Both set it: the terminal property — this contract can no longer mint or admin-burn — is the same either way.",
       "type": "boolean"
     },
     "choice_factory": {

--- a/contracts/choice_mts_issuer/schema/launches_response.json
+++ b/contracts/choice_mts_issuer/schema/launches_response.json
@@ -33,7 +33,7 @@
       ],
       "properties": {
         "admin_renounced": {
-          "description": "`true` once `RenounceDenomAdmin` has relinquished this contract's tokenfactory admin over the denom (finding C-M2).",
+          "description": "`true` once `RenounceDenomAdmin` or `HandOverDenomAdminToErc20` has relinquished this contract's tokenfactory admin over the denom (finding C-M2). Both set it: the terminal property — this contract can no longer mint or admin-burn — is the same either way.",
           "type": "boolean"
         },
         "choice_factory": {

--- a/contracts/choice_mts_issuer/src/contract.rs
+++ b/contracts/choice_mts_issuer/src/contract.rs
@@ -98,10 +98,19 @@ const MAX_QUERY_LIMIT: u32 = 100;
 /// matching `LaunchRecord`.
 const REPLY_CREATE_TOKEN_PAIR: u64 = 1;
 
-/// 20-zero-byte bech32 burn address. `MsgChangeAdmin` to this address is the
-/// canonical tokenfactory-admin "renounce" on Injective (an empty `new_admin`
-/// is chain-rejected). See `feedback_inj_tokenfactory_admin_revoke_burn_bech32`
-/// and finding C-M2.
+/// 20-zero-byte bech32 burn address. Conventionally the tokenfactory-admin
+/// "renounce" target on Injective (an empty `new_admin` is chain-rejected).
+///
+/// ⛔ **No longer used as a renounce target here, and it must not become one
+/// again.** The burn path compares `MsgBurn.Sender` — which the bank precompile
+/// sets to the calling ERC20 — against the denom admin, so parking the admin
+/// here makes every holder burn revert `unauthorized account` with no way back:
+/// `MsgChangeAdmin` requires the current admin's signature. Nine mainnet launch
+/// denoms are stranded exactly that way. The admin now goes to the launch's own
+/// ERC20 instead; see `HandOverDenomAdminToErc20`.
+///
+/// It survives as a REJECTION value: an issuer configured with this as its
+/// `admin` would be unadministrable, so instantiate refuses it below.
 const DEAD_TOKENFACTORY_ADMIN: &str = "inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49";
 
 /// Payload carried into the `MsgCreateTokenPair` reply so the handler can
@@ -144,8 +153,8 @@ pub fn instantiate(
     // The admin governs the issuer via a two-step handoff (UpdateAdmin/
     // AcceptAdmin). Setting it to the tokenfactory dead-burn address at deploy
     // would permanently brick governance (no key can ever AcceptAdmin), so
-    // reject the obvious foot-gun. Rotation to the dead address is still
-    // possible later only through the denom-admin renounce path, not here.
+    // reject the obvious foot-gun. Since 1.2.0 nothing in this contract rotates
+    // anything to the dead address at all — see the constant's own doc.
     if admin.as_str() == DEAD_TOKENFACTORY_ADMIN {
         return Err(ContractError::AdminIsDeadAddress {});
     }
@@ -345,6 +354,10 @@ pub fn execute(
             evm_authority,
             internal_id,
         } => execute_renounce_denom_admin(deps, env, info, evm_authority, internal_id),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority,
+            internal_id,
+        } => execute_hand_over_denom_admin_to_erc20(deps, env, info, evm_authority, internal_id),
         ExecuteMsg::UpdateAdmin { new_admin } => execute_update_admin(deps, info, new_admin),
         ExecuteMsg::AcceptAdmin {} => execute_accept_admin(deps, info),
         ExecuteMsg::UpdateKeeper { new_keeper } => execute_update_keeper(deps, info, new_keeper),
@@ -1204,11 +1217,27 @@ fn execute_renounce_denom_admin(
         ));
     }
 
+    // The admin goes to the launch's OWN paired ERC20, not to the dead address.
+    //
+    // Both choices relinquish this contract's mint/admin-burn powers, which is
+    // all C-M2 ever asked for. The difference is what the CHAIN can still do
+    // afterwards: the burn path needs `admin == the ERC20 contract`
+    // (`verifyBurnFromPermissions`), so rotating to the dead address does not
+    // merely fail to help — it permanently forecloses every holder burn, with no
+    // way back, because `MsgChangeAdmin` requires the current admin to sign.
+    // Nine mainnet launch denoms are already in that state.
+    //
+    // Handing it to the ERC20 keeps the mint gate just as closed: the only
+    // account that can drive `MsgMint` is then the contract itself, reachable
+    // only through its `Ownable`-gated `mint`, whose owner is this contract's
+    // 20-byte EVM mirror — an address with no private key and no wasm→EVM path
+    // to act through. See `HandOverDenomAdminToErc20`.
+    let new_admin = erc20_admin_bech32(deps.as_ref(), &record)?;
     messages.push(
         MsgChangeAdmin {
             sender: env.contract.address.to_string(),
             denom: record.denom.clone(),
-            new_admin: DEAD_TOKENFACTORY_ADMIN.to_string(),
+            new_admin: new_admin.to_string(),
         }
         .into(),
     );
@@ -1220,7 +1249,128 @@ fn execute_renounce_denom_admin(
         .add_attribute("internal_id", internal_id.to_string())
         .add_attribute("denom", record.denom)
         .add_attribute("stranded_burned", residual)
-        .add_attribute("new_admin", DEAD_TOKENFACTORY_ADMIN))
+        .add_attribute("new_admin", new_admin))
+}
+
+/// Resolve a launch record's paired ERC20 into the bech32 address the
+/// tokenfactory will compare `MsgBurn.Sender` against.
+///
+/// The EVM address and the Cosmos address are the same 20 bytes in two
+/// encodings — `bank.go` builds the burn message with
+/// `sdk.AccAddress(calledAddress.Bytes()).String()` — so this is
+/// `addr_humanize` over the recorded hex, and nothing cleverer.
+///
+/// Validated rather than trusted: `MsgChangeAdmin` cannot be undone by anyone
+/// but the new admin, so a malformed address here would brick the denom exactly
+/// the way the dead address does.
+fn erc20_admin_bech32(
+    deps: Deps<InjectiveQueryWrapper>,
+    record: &LaunchRecord,
+) -> Result<Addr, ContractError> {
+    let raw = record
+        .erc20_address
+        .as_deref()
+        .ok_or(ContractError::Erc20AddressUnknown {
+            id: record.internal_id,
+        })?;
+    let hex = raw.strip_prefix("0x").unwrap_or(raw);
+    if hex.len() != 40 {
+        return Err(ContractError::InvalidErc20Address {
+            got: raw.to_string(),
+            reason: format!("expected 40 hex digits, got {}", hex.len()),
+        });
+    }
+    let mut bytes = [0u8; 20];
+    for (i, b) in bytes.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).map_err(|_| {
+            ContractError::InvalidErc20Address {
+                got: raw.to_string(),
+                reason: "non-hex digit".to_string(),
+            }
+        })?;
+    }
+    deps.api
+        .addr_humanize(&CanonicalAddr::from(bytes.as_slice()))
+        .map_err(ContractError::Std)
+}
+
+/// Hand the denom's tokenfactory admin to its own paired ERC20 — the step that
+/// makes a launch token burnable by its holders. See
+/// [`crate::msg::ExecuteMsg::HandOverDenomAdminToErc20`] for the mechanism.
+///
+/// This is the REMEDIATION entry point, so unlike `RenounceDenomAdmin` it is
+/// deliberately not gated on `Delivered`: the launches that need it are spread
+/// across every status, and the only thing that actually matters is that this
+/// contract is still the admin (`!admin_renounced`). Once it is not, nothing
+/// can help — `MsgChangeAdmin` requires the current admin's signature.
+///
+/// Sets the same `admin_renounced` flag, because the terminal property is
+/// identical: after this the issuer can neither `MsgMint` nor admin-`MsgBurn`.
+fn execute_hand_over_denom_admin_to_erc20(
+    deps: DepsMut<InjectiveQueryWrapper>,
+    env: Env,
+    info: MessageInfo,
+    evm_authority: String,
+    internal_id: u64,
+) -> Result<Response<InjectiveMsgWrapper>, ContractError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.keeper && info.sender != config.admin {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    let evm_authority = deps.api.addr_validate(&evm_authority)?;
+    let mut record = LAUNCHES
+        .may_load(deps.storage, (&evm_authority, internal_id))?
+        .ok_or(ContractError::LaunchNotFound { id: internal_id })?;
+
+    if record.admin_renounced {
+        return Err(ContractError::DenomAdminAlreadyRenounced { id: internal_id });
+    }
+
+    // Resolve BEFORE mutating: a record with no (or a malformed) erc20_address
+    // must leave the launch exactly as it was, still holding a movable admin,
+    // rather than burning the flag on a rotation that never happened.
+    let new_admin = erc20_admin_bech32(deps.as_ref(), &record)?;
+
+    record.admin_renounced = true;
+    LAUNCHES.save(deps.storage, (&evm_authority, internal_id), &record)?;
+
+    let mut messages: Vec<CosmosMsg<InjectiveMsgWrapper>> = Vec::new();
+
+    // Same sweep as `RenounceDenomAdmin`, for the same reason: this is the last
+    // moment a self-burn is possible, and a residual left here after the admin
+    // moves is stranded permanently. Zero on every ordinary launch.
+    let residual = deps
+        .querier
+        .query_balance(env.contract.address.as_str(), &record.denom)?
+        .amount;
+    if !residual.is_zero() {
+        messages.push(injective_cosmwasm::msg::create_burn_tokens_msg(
+            env.contract.address.clone(),
+            Coin {
+                denom: record.denom.clone(),
+                amount: residual,
+            },
+        ));
+    }
+
+    messages.push(
+        MsgChangeAdmin {
+            sender: env.contract.address.to_string(),
+            denom: record.denom.clone(),
+            new_admin: new_admin.to_string(),
+        }
+        .into(),
+    );
+
+    Ok(Response::new()
+        .add_messages(messages)
+        .add_attribute("action", "hand_over_denom_admin_to_erc20")
+        .add_attribute("evm_authority", evm_authority)
+        .add_attribute("internal_id", internal_id.to_string())
+        .add_attribute("denom", record.denom)
+        .add_attribute("stranded_burned", residual)
+        .add_attribute("new_admin", new_admin))
 }
 
 /// Step 1 of the two-step admin rotation: park `new_admin` as pending. The

--- a/contracts/choice_mts_issuer/src/error.rs
+++ b/contracts/choice_mts_issuer/src/error.rs
@@ -214,4 +214,14 @@ pub enum ContractError {
 
     #[error("Issuer is paused; keeper-initiated RefundFailedLaunch is halted (the admin may still refund past the deadline)")]
     KeeperRefundPaused {},
+
+    #[error(
+        "launch {id} has no paired ERC20 recorded, so there is no address to hand the denom admin to. `erc20_address` is captured in the MsgCreateTokenPair reply and is always populated once the launch reached Registered"
+    )]
+    Erc20AddressUnknown { id: u64 },
+
+    #[error(
+        "recorded erc20_address `{got}` is not a 20-byte 0x-prefixed hex address ({reason}) — refusing to derive a bech32 admin from it, because MsgChangeAdmin to a wrong address is irreversible"
+    )]
+    InvalidErc20Address { got: String, reason: String },
 }

--- a/contracts/choice_mts_issuer/src/msg.rs
+++ b/contracts/choice_mts_issuer/src/msg.rs
@@ -181,17 +181,69 @@ pub enum ExecuteMsg {
     },
 
     /// Keeper-or-admin, post-`Delivered`: relinquish this contract's
-    /// tokenfactory admin over the launch denom by rotating the admin to the
-    /// 20-zero-byte burn-address convention via `MsgChangeAdmin` (finding
+    /// tokenfactory admin over the launch denom via `MsgChangeAdmin` (finding
     /// C-M2). After this the issuer can no longer `MsgMint` new supply or
     /// admin-`MsgBurn`-from holders for the denom.
     ///
-    /// NOTE: this renounces the *tokenfactory* admin only. The auto-deployed
+    /// 🔴 **As of 1.2.0 the admin goes to the launch's own paired ERC20, not to
+    /// the 20-zero-byte burn address.** Both relinquish this contract's powers,
+    /// which is all C-M2 asked for, but the dead address ALSO forecloses every
+    /// holder burn forever — `verifyBurnFromPermissions` requires
+    /// `admin == the ERC20 contract`, and `MsgChangeAdmin` needs the current
+    /// admin to sign, so there is no way back. Nine mainnet launch denoms are
+    /// already stranded that way. See
+    /// [`ExecuteMsg::HandOverDenomAdminToErc20`], which this now mirrors.
+    ///
+    /// NOTE: this relinquishes the *tokenfactory* admin only. The auto-deployed
     /// `MintBurnBankERC20` owner is the issuer's lower-20-byte EVM address; a
     /// CosmWasm contract cannot sign the EVM tx to renounce that ERC20
-    /// ownership, so that step must be performed separately by the issuer's
-    /// controller on the EVM side (deployment runbook item).
+    /// ownership. That is harmless here — the owner is an address with no
+    /// private key, and there is no wasm→EVM call path on Injective for this
+    /// contract to reach `mint` through — but a keeper EOA issuing its own
+    /// tokens MUST renounce, because then the owner is a real signer.
     RenounceDenomAdmin {
+        evm_authority: String,
+        internal_id: u64,
+    },
+
+    /// Keeper-or-admin: hand this denom's tokenfactory admin to its OWN paired
+    /// `MintBurnBankERC20`, which is what makes the token burnable by its
+    /// holders.
+    ///
+    /// ## Why this exists
+    ///
+    /// `evm/precompiles/bank/bank.go:mintBurn` turns a holder's `burn(uint256)`
+    /// on a `factory/…`-backed ERC20 into
+    /// `MsgBurn{ Sender: <the ERC20 contract>, BurnFromAddress: <the holder> }`.
+    /// `Sender != BurnFrom`, so it is not a self-burn, so
+    /// `tokenfactory/keeper/burn_permissions.go:verifyBurnFromPermissions`
+    /// demands BOTH `AdminBurnAllowed == true` AND
+    /// **`admin == the ERC20 contract`**. `RegisterLaunch` sets
+    /// `allow_admin_burn = true` but leaves the admin as THIS CONTRACT, so
+    /// every launch token issued to date reverts `unauthorized account` on a
+    /// holder burn — and, by the same asymmetry, on `mint`.
+    ///
+    /// This message sends the missing `MsgChangeAdmin(denom,
+    /// bech32(erc20_address))`. Measured on testnet 2026-09-06: with it, a
+    /// holder burn reduces real bank supply; without it, nothing can.
+    ///
+    /// ## What it costs
+    ///
+    /// After the rotation this contract is no longer the denom admin, so it can
+    /// no longer `MsgMint` or admin-`MsgBurn` — the same terminal property
+    /// [`ExecuteMsg::RenounceDenomAdmin`] was written to guarantee, which is why
+    /// both set `admin_renounced`. The mint gate moves to the ERC20's `Ownable`
+    /// owner, which is this contract's own 20-byte EVM mirror: an address with
+    /// no private key, and unreachable from CosmWasm because Injective has no
+    /// wasm→EVM call path (the precompile set is bank / bindings / exchange /
+    /// oracle / staking). So mint stays dead, and burn opens.
+    ///
+    /// ⛔ **Only available while this contract is still the admin.** Once the
+    /// admin is the dead address, `MsgChangeAdmin` needs a signature nobody
+    /// holds and the denom is permanently unburnable. Any residual balance is
+    /// burnt first, exactly as `RenounceDenomAdmin` does, because that is also
+    /// the last moment a self-burn is possible.
+    HandOverDenomAdminToErc20 {
         evm_authority: String,
         internal_id: u64,
     },
@@ -313,8 +365,10 @@ pub struct LaunchResponse {
     /// `AddNativeTokenDecimals` call to a `choice_factory`. `None` if the
     /// consumer dApp opted out and is registering decimals separately.
     pub choice_factory: Option<String>,
-    /// `true` once `RenounceDenomAdmin` has relinquished this contract's
-    /// tokenfactory admin over the denom (finding C-M2).
+    /// `true` once `RenounceDenomAdmin` or `HandOverDenomAdminToErc20` has
+    /// relinquished this contract's tokenfactory admin over the denom (finding
+    /// C-M2). Both set it: the terminal property — this contract can no longer
+    /// mint or admin-burn — is the same either way.
     pub admin_renounced: bool,
 }
 

--- a/contracts/choice_mts_issuer/src/state.rs
+++ b/contracts/choice_mts_issuer/src/state.rs
@@ -149,11 +149,19 @@ pub struct LaunchRecord {
     /// is registering decimals separately. Stored for audit / dashboards;
     /// not used to gate any downstream action.
     pub choice_factory: Option<Addr>,
-    /// `true` once `RenounceDenomAdmin` has rotated this denom's tokenfactory
-    /// admin to the burn-address convention, relinquishing the issuer's
-    /// `MsgMint` / admin-`MsgBurn`-from powers over the denom. Audit + a guard
-    /// against a double-renounce (the second `MsgChangeAdmin` would revert
-    /// anyway, but we reject early with a clear error). See finding C-M2.
+    /// `true` once this denom's tokenfactory admin has been rotated AWAY from
+    /// this contract — by `RenounceDenomAdmin` or `HandOverDenomAdminToErc20`,
+    /// which since 1.2.0 both target the launch's paired ERC20 — relinquishing
+    /// the issuer's `MsgMint` / admin-`MsgBurn`-from powers over the denom.
+    /// Audit + a guard against a double-rotation (the second `MsgChangeAdmin`
+    /// would revert anyway, but we reject early with a clear error). See finding
+    /// C-M2.
+    ///
+    /// 🔴 It is also the "can this still be remediated?" flag: once the admin
+    /// has moved, only the NEW admin can move it again, so a launch that was
+    /// rotated to the dead address by a pre-1.2.0 build is permanently
+    /// unburnable. That is why the handover resolves the ERC20 address BEFORE
+    /// setting this.
     pub admin_renounced: bool,
     /// Audit M-3: snapshot of [`Config::verify_seeder_derivation`] at the moment
     /// this launch was registered — i.e. whether the sink-address (and CLMM

--- a/contracts/choice_mts_issuer/src/tests.rs
+++ b/contracts/choice_mts_issuer/src/tests.rs
@@ -190,6 +190,33 @@ fn default_denom(internal_id: u64) -> String {
     denom_with_salt(internal_id, TEST_SALT)
 }
 
+/// The paired ERC20 the chain auto-deploys at `MsgCreateTokenPair`. In
+/// production the reply handler patches this in; `register_default` stops short
+/// of the reply, so tests that exercise the admin handover set it by hand.
+const TEST_ERC20_HEX: &str = "0x1234567890AbcdEF1234567890aBcdef12345678";
+
+/// Patch `erc20_address` onto a launch record and return the bech32 the
+/// tokenfactory will compare `MsgBurn.Sender` against — the same 20 bytes,
+/// `addr_humanize`d, which is exactly what `bank.go` does with
+/// `sdk.AccAddress(calledAddress.Bytes())`.
+fn set_erc20(deps: &mut Deps, internal_id: u64) -> String {
+    let authority = deps.api.addr_make("evm_authority");
+    let mut rec = LAUNCHES
+        .load(deps.as_ref().storage, (&authority, internal_id))
+        .unwrap();
+    rec.erc20_address = Some(TEST_ERC20_HEX.to_string());
+    LAUNCHES
+        .save(deps.as_mut().storage, (&authority, internal_id), &rec)
+        .unwrap();
+    let bytes = (0..20)
+        .map(|i| u8::from_str_radix(&TEST_ERC20_HEX[2 + i * 2..4 + i * 2], 16).unwrap())
+        .collect::<Vec<u8>>();
+    deps.api
+        .addr_humanize(&CanonicalAddr::from(bytes.as_slice()))
+        .unwrap()
+        .to_string()
+}
+
 /// Stub the seeder sink's `SinkConfig` so `DeliverToSeeder` (P2-B) sees a sink
 /// genuinely configured for launch `internal_id` (matching token/pair denom).
 /// Also marks the address as a hosting contract for the old ghost-check.
@@ -1618,6 +1645,7 @@ fn renounce_denom_admin_after_delivered_emits_change_admin() {
     let evm_authority = deps.api.addr_make("evm_authority").to_string();
     let seeder = deps.api.addr_make("seeder_addr").to_string();
     install_matching_sink(&mut deps, &seeder, 5);
+    let erc20_bech32 = set_erc20(&mut deps, 5);
     let keeper = deps.api.addr_make("keeper");
 
     execute(
@@ -1649,7 +1677,13 @@ fn renounce_denom_admin_after_delivered_emits_change_admin() {
             assert_eq!(type_url, MsgChangeAdmin::TYPE_URL);
             let decoded = MsgChangeAdmin::decode(value.as_slice()).unwrap();
             assert_eq!(decoded.denom, default_denom(5));
-            assert_eq!(
+            // The admin goes to the launch's OWN ERC20, never to the dead
+            // address: `verifyBurnFromPermissions` compares `MsgBurn.Sender`
+            // (which the precompile sets to the calling contract) against this
+            // field, so the dead address would foreclose every holder burn with
+            // no way back.
+            assert_eq!(decoded.new_admin, erc20_bech32);
+            assert_ne!(
                 decoded.new_admin,
                 "inj1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqe2hm49"
             );
@@ -1694,6 +1728,7 @@ fn renounce_denom_admin_burns_stranded_residual_before_change_admin() {
     let evm_authority = deps.api.addr_make("evm_authority").to_string();
     let seeder = deps.api.addr_make("seeder_addr").to_string();
     install_matching_sink(&mut deps, &seeder, 33);
+    set_erc20(&mut deps, 33);
     let keeper = deps.api.addr_make("keeper");
 
     execute(
@@ -1789,6 +1824,249 @@ fn renounce_denom_admin_rejects_unauthorized() {
 // --------------------------------------------------------------------------
 // C-M3: DeliverToSeeder refuses a ghost seeder address
 // --------------------------------------------------------------------------
+
+// --------------------------------------------------------------------------
+// HandOverDenomAdminToErc20 — the step that makes a launch token burnable.
+//
+// `bank.go:mintBurn` turns a holder's `burn` on a `factory/...` denom into
+// `MsgBurn{ Sender: <the ERC20 contract>, BurnFromAddress: <the holder> }`, and
+// `verifyBurnFromPermissions` then requires `admin == that contract`. Leaving
+// the admin as the issuer (or rotating it to the dead address) is what makes
+// every holder burn revert `unauthorized account`.
+// --------------------------------------------------------------------------
+
+#[test]
+fn hand_over_denom_admin_sets_the_admin_to_the_paired_erc20() {
+    let mut deps = setup();
+    register_default(&mut deps, 7).unwrap();
+    let evm_authority = deps.api.addr_make("evm_authority").to_string();
+    let erc20_bech32 = set_erc20(&mut deps, 7);
+    let keeper = deps.api.addr_make("keeper");
+
+    // Deliberately NOT Delivered. The launches that need remediation are spread
+    // across every status, and the only thing that matters is that this contract
+    // is still the admin.
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&keeper, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority: evm_authority.clone(),
+            internal_id: 7,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(res.messages.len(), 1);
+    #[allow(deprecated)]
+    match &res.messages[0].msg {
+        CosmosMsg::Stargate { type_url, value } => {
+            assert_eq!(type_url, MsgChangeAdmin::TYPE_URL);
+            let decoded = MsgChangeAdmin::decode(value.as_slice()).unwrap();
+            assert_eq!(decoded.denom, default_denom(7));
+            assert_eq!(decoded.new_admin, erc20_bech32);
+        }
+        other => panic!("expected Stargate MsgChangeAdmin, got {:?}", other),
+    }
+
+    let rec = LAUNCHES
+        .load(
+            deps.as_ref().storage,
+            (&deps.api.addr_make("evm_authority"), 7),
+        )
+        .unwrap();
+    assert!(rec.admin_renounced, "the issuer is no longer the admin");
+}
+
+#[test]
+fn hand_over_denom_admin_burns_stranded_residual_first() {
+    // Same reasoning as RenounceDenomAdmin: this is the last moment a self-burn
+    // is possible, so a residual left here would strand permanently.
+    let mut deps = setup();
+    register_default(&mut deps, 8).unwrap();
+    let evm_authority = deps.api.addr_make("evm_authority").to_string();
+    set_erc20(&mut deps, 8);
+    let keeper = deps.api.addr_make("keeper");
+
+    let stranded = Uint128::new(4_242u128);
+    let issuer_addr = mock_env().contract.address.to_string();
+    deps.querier
+        .with_balance(&[(&issuer_addr, coins(stranded.u128(), default_denom(8)))]);
+
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&keeper, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority,
+            internal_id: 8,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(res.messages.len(), 2);
+    match &res.messages[0].msg {
+        CosmosMsg::Custom(w) => match &w.msg_data {
+            InjectiveMsg::Burn { amount, .. } => {
+                assert_eq!(amount.denom, default_denom(8));
+                assert_eq!(amount.amount, stranded);
+            }
+            other => panic!("expected Burn, got {:?}", other),
+        },
+        other => panic!("expected Custom Injective Burn, got {:?}", other),
+    }
+    #[allow(deprecated)]
+    match &res.messages[1].msg {
+        CosmosMsg::Stargate { type_url, .. } => assert_eq!(type_url, MsgChangeAdmin::TYPE_URL),
+        other => panic!("expected Stargate MsgChangeAdmin, got {:?}", other),
+    }
+}
+
+#[test]
+fn hand_over_denom_admin_without_an_erc20_leaves_the_record_untouched() {
+    // The failure that matters. If the flag were set before the address was
+    // resolved, a record with no pair would be marked as handed over while no
+    // rotation happened — and `admin_renounced` is checked on the way in, so the
+    // launch could never be retried. It would look remediated and be dead.
+    let mut deps = setup();
+    register_default(&mut deps, 9).unwrap();
+    let evm_authority = deps.api.addr_make("evm_authority").to_string();
+    let keeper = deps.api.addr_make("keeper");
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&keeper, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority,
+            internal_id: 9,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ContractError::Erc20AddressUnknown { id: 9 }),
+        "got {:?}",
+        err
+    );
+
+    let rec = LAUNCHES
+        .load(
+            deps.as_ref().storage,
+            (&deps.api.addr_make("evm_authority"), 9),
+        )
+        .unwrap();
+    assert!(
+        !rec.admin_renounced,
+        "a failed handover must leave the admin movable, or the launch is unrecoverable"
+    );
+}
+
+#[test]
+fn hand_over_denom_admin_rejects_a_second_call() {
+    let mut deps = setup();
+    register_default(&mut deps, 10).unwrap();
+    let evm_authority = deps.api.addr_make("evm_authority").to_string();
+    set_erc20(&mut deps, 10);
+    let keeper = deps.api.addr_make("keeper");
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&keeper, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority: evm_authority.clone(),
+            internal_id: 10,
+        },
+    )
+    .unwrap();
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&keeper, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority,
+            internal_id: 10,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ContractError::DenomAdminAlreadyRenounced { id: 10 }),
+        "got {:?}",
+        err
+    );
+}
+
+#[test]
+fn hand_over_denom_admin_requires_keeper_or_admin() {
+    let mut deps = setup();
+    register_default(&mut deps, 11).unwrap();
+    let evm_authority = deps.api.addr_make("evm_authority").to_string();
+    set_erc20(&mut deps, 11);
+
+    let stranger = deps.api.addr_make("stranger");
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&stranger, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority: evm_authority.clone(),
+            internal_id: 11,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ContractError::Unauthorized {}),
+        "got {:?}",
+        err
+    );
+
+    // The admin is the other authorised caller — the keeper may be lost.
+    let admin = deps.api.addr_make("admin");
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority,
+            internal_id: 11,
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn hand_over_denom_admin_rejects_a_malformed_erc20_address() {
+    // MsgChangeAdmin is irreversible by anyone but the new admin, so a wrong
+    // address bricks the denom exactly the way the dead address does.
+    let mut deps = setup();
+    register_default(&mut deps, 12).unwrap();
+    let authority = deps.api.addr_make("evm_authority");
+    let mut rec = LAUNCHES
+        .load(deps.as_ref().storage, (&authority, 12))
+        .unwrap();
+    rec.erc20_address = Some("0xdeadbeef".to_string());
+    LAUNCHES
+        .save(deps.as_mut().storage, (&authority, 12), &rec)
+        .unwrap();
+
+    let keeper = deps.api.addr_make("keeper");
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&keeper, &[]),
+        ExecuteMsg::HandOverDenomAdminToErc20 {
+            evm_authority: authority.to_string(),
+            internal_id: 12,
+        },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, ContractError::InvalidErc20Address { .. }),
+        "got {:?}",
+        err
+    );
+}
 
 #[test]
 fn deliver_to_seeder_rejects_ghost_seeder_addr() {


### PR DESCRIPTION
A launch token's holder cannot burn it. `burn(uint256)` reverts `Error(string) "unauthorized account"` on **every launch this issuer has ever made** — measured on testnet CV2W from an address holding 234,175,660 of it, and on mainnet.

## Why, and why it looked fine

The ERC20 is not the reason. `burn` is stock `ERC20Burnable`, and a bytecode grep for `0x42966c68` finds it in every shape. `evm/precompiles/bank/bank.go:mintBurn` **branches** on `GetDenomType(denom)`:

| denom type | precompile does | authorization |
| --- | --- | --- |
| `erc20:0x…` | `erc20Keeper.BurnERC20` | none at all |
| `factory/…` | `MsgBurn{Sender: <the ERC20 contract>, BurnFromAddress: <the holder>}` | `AdminBurnAllowed` **and** `admin == that contract` |

`RegisterLaunch` sets `allow_admin_burn = true` correctly, but leaves the denom admin as **this contract**, so `Sender != admin` and the burn fails by construction.

🔴 The same asymmetry silently kills `mint`: from a non-owner it reverts `0x118cdaa7`, and **from the owner** `"failed to mint: unauthorized account"` — it clears Ownable and dies at the precompile. A launch token's supply is frozen by a bug, not by the renounce believed to be doing it.

## What this adds

**`HandOverDenomAdminToErc20`** sends the missing `MsgChangeAdmin(denom, bech32(erc20_address))`. Deliberately **not** gated on `Delivered`: the launches needing remediation span every status, and the only thing that matters is that this contract is still the admin.

**`RenounceDenomAdmin` now targets the same address.** Rotating to the dead address relinquishes exactly what C-M2 asked for — but it *also* forecloses every holder burn permanently, because `MsgChangeAdmin` requires the current admin to sign. That is not a theoretical cost:

| mainnet launch denoms (all 179 surveyed, 2026-09-06) | count |
| --- | --- |
| `AdminBurnAllowed = true`, admin = this contract — **remediable** | **170** |
| `AdminBurnAllowed = true`, admin = dead — **lost forever** | **9** |

Repointing it means new launches are born burnable the moment this migration lands, with no keeper change.

## Does this reopen minting?

No. After the rotation the only account that can drive `MsgMint` is the ERC20 contract itself, reachable only through its `Ownable`-gated `mint`, whose owner is **this contract's own 20-byte EVM mirror** — an address with no private key, and unreachable from here because Injective has no wasm→EVM call path (precompile set is bank / bindings / exchange / oracle / staking).

⚠️ That reasoning is specific to a *contract* issuer. A keeper EOA issuing its own tokens **must** call `renounceOwnership()`, because there the owner is a real signer. Documented on the message.

## The failure mode worth reviewing

`erc20_admin_bech32` resolves and validates **before** `admin_renounced` is set. If the flag were set first, a record with no pair (or a malformed one) would be marked remediated while no rotation happened — and since `admin_renounced` is checked on entry, it could never be retried. It would look fixed and be dead. `hand_over_denom_admin_without_an_erc20_leaves_the_record_untouched` pins this.

The address is validated rather than trusted for the same reason the dead address is a problem: `MsgChangeAdmin` cannot be undone by anyone but the new admin, so a wrong 20 bytes bricks the denom identically.

## What I checked

- `cargo test -p choice-mts-issuer`: **80 pass, 0 fail** (6 new). Two existing renounce tests were updated — they asserted the dead address, which is the behaviour being changed; both now assert the ERC20 and one asserts `!=` the dead address.
- `cargo clippy --all-targets` clean, `cargo fmt` applied, `--target wasm32-unknown-unknown --release` builds.
- Schema regenerated (`cargo run --example mts_issuer_schema`).
- Chain source read at `injective-core` **v1.20.3-safeharbor.2** in a pinned clone, hash-compared against the tag — not the local checkout, which sits on an unmerged `feat/cosmwasm-query-precompile` branch.
- 🔴 **Proven on chain, not just reasoned.** The same five-step sequence run from an EOA on testnet produced a genuinely burnable token: a holder burn moved real *bank* supply 1,000,000,000 → 876,543,211 (Cosmos `bank/supply/by_denom` agreeing), and `mint` then reverted `OwnableUnauthorizedAccount`. A full pad launch was then walked end to end — created, bound, curve filled, graduated, and burned after graduation.

## Deploying this

⛔ Not done here. Needs the optimized wasm (`./build_release.sh`, the Docker workspace-optimizer — a raw `cargo build` emits bulk-memory ops `injectived` rejects), then a store + `MsgMigrateContract` through the Choice admin **48h timelock**. **The remediation must land before the issuer is decommissioned** — after that, the 170 close the same way the 9 already have.

Related: `shroom_launchpad` #150 (the probe and the EOA issuance tool), `choice_v2_workspace` #19 (SPROUT §9.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)